### PR TITLE
fix: Fixed PaymasterParams encoding and added tests

### DIFF
--- a/src/network/unsigned_tx/eip712/meta.rs
+++ b/src/network/unsigned_tx/eip712/meta.rs
@@ -113,9 +113,13 @@ impl Decodable for PaymasterParams {
 
 impl Encodable for PaymasterParams {
     fn encode(&self, out: &mut dyn alloy::rlp::BufMut) {
+        // paymaster params have to be encoded as a list.
+        let h = Header {
+            list: true,
+            payload_length: self.paymaster.length() + self.paymaster_input.length(),
+        };
+        h.encode(out);
         self.paymaster.encode(out);
         self.paymaster_input.encode(out);
     }
-
-    // TODO: implement length method
 }


### PR DESCRIPTION
* paymaster params have to be encoded as a RLP list (not separate). Decoding was done correctly, but encoding not.
* added tests to catch this