### PR TITLE
feat: add additional configuration methods to TransactionRequest

### DIFF
--- a/src/network/transaction_request/mod.rs
+++ b/src/network/transaction_request/mod.rs
@@ -20,6 +20,11 @@ pub struct TransactionRequest {
 
 // TODO: Extension trait for `TransactionBuilder`?
 impl TransactionRequest {
+    pub fn with_base(mut self, base: alloy::rpc::types::transaction::TransactionRequest) -> Self {
+        self.base = base;
+        self
+    }
+
     pub fn gas_per_pubdata(&self) -> Option<U256> {
         self.eip_712_meta.as_ref().map(|meta| meta.gas_per_pubdata)
     }
@@ -43,6 +48,17 @@ impl TransactionRequest {
 
     pub fn with_paymaster(mut self, paymaster_params: PaymasterParams) -> Self {
         self.set_paymaster(paymaster_params);
+        self
+    }
+
+    pub fn set_factory_deps(&mut self, factory_deps: Vec<Bytes>) {
+        self.eip_712_meta
+            .get_or_insert_with(Eip712Meta::default)
+            .factory_deps = factory_deps;
+    }
+
+    pub fn with_factory_deps(mut self, factory_deps: Vec<Bytes>) -> Self {
+        self.set_factory_deps(factory_deps);
         self
     }
 

--- a/src/network/transaction_request/mod.rs
+++ b/src/network/transaction_request/mod.rs
@@ -20,11 +20,6 @@ pub struct TransactionRequest {
 
 // TODO: Extension trait for `TransactionBuilder`?
 impl TransactionRequest {
-    pub fn with_base(mut self, base: alloy::rpc::types::transaction::TransactionRequest) -> Self {
-        self.base = base;
-        self
-    }
-
     pub fn gas_per_pubdata(&self) -> Option<U256> {
         self.eip_712_meta.as_ref().map(|meta| meta.gas_per_pubdata)
     }
@@ -382,5 +377,14 @@ impl TransactionBuilder<Zksync> for TransactionRequest {
         wallet: &W,
     ) -> Result<<Zksync as Network>::TxEnvelope, TransactionBuilderError<Zksync>> {
         Ok(wallet.sign_request(self).await?)
+    }
+}
+
+impl From<alloy::rpc::types::transaction::TransactionRequest> for TransactionRequest {
+    fn from(value: alloy::rpc::types::transaction::TransactionRequest) -> Self {
+        Self {
+            base: value,
+            ..Default::default()
+        }
     }
 }


### PR DESCRIPTION
Adds additional configuration methods from https://github.com/nbaztec/alloy-zksync/commit/0adab979cf081350a9c0d7a42d4e8905a39d8c92#diff-1a9e2e7a035e7c35978db3881e2889f3ef75b2605ec9d61fc07d2b00efca34b5R23 to `TransactionRequest` for configuring the `factory_deps` and the `base` transaction.