### PR TITLE
feat: add missing zks namespace methods to zksync provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
+ "chrono",
  "futures-utils-wasm",
  "hex",
  "k256",
@@ -614,6 +615,21 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -974,6 +990,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets",
+]
 
 [[package]]
 name = "const-hex"
@@ -1615,6 +1646,29 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3323,6 +3377,15 @@ name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "ZKsync network implementation for alloy"
 [dependencies]
 alloy = { version = "0.4", features = ["full", "rlp", "serde", "sol-types"] } # TODO: Set features granularly?
 async-trait = "0.1.80"
+chrono = { version = "0.4.38", features = ["serde"] }
 futures-utils-wasm = "0.1.0"
 k256 = "0.13.3"
 rand = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod contracts;
 pub mod network;
 pub mod node_bindings;
 pub mod provider;
+pub mod types;
 pub mod wallet;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,16 +1,13 @@
+use crate::network::transaction_request::TransactionRequest;
+use crate::network::Zksync;
+use crate::types::*;
 use alloy::primitives::{Address, Bytes, B256, U256, U64};
 use alloy::providers::fillers::{ChainIdFiller, JoinFill, NonceFiller, RecommendedFillers};
 use alloy::providers::{Identity, Provider, ProviderBuilder, ProviderCall};
 use alloy::rpc::client::NoParams;
 use alloy::transports::{BoxTransport, Transport};
-use chrono::{DateTime, Utc};
 use fillers::Eip712FeeFiller;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::network::transaction_request::TransactionRequest;
-use crate::network::unsigned_tx::eip712::PaymasterParams;
-use crate::network::Zksync;
 
 pub use self::provider_builder_ext::ProviderBuilderExt;
 
@@ -18,283 +15,7 @@ pub mod fillers;
 pub mod layers;
 mod provider_builder_ext;
 
-/// Response type for `zks_estimateFee`.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct Eip712Fee {
-    /// Amount of gas to be spent on the transaction.
-    #[serde(with = "alloy::serde::quantity")]
-    pub gas_limit: u64,
-    /// Maximum gas user agrees to spend on a single pubdata byte published to L1.
-    pub gas_per_pubdata_limit: U256,
-    /// EIP-1559 gas price.
-    #[serde(with = "alloy::serde::quantity")]
-    pub max_fee_per_gas: u128,
-    /// EIP-1559 tip.
-    #[serde(with = "alloy::serde::quantity")]
-    pub max_priority_fee_per_gas: u128,
-}
-
-/// Response type for `zks_getBridgeContracts`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BridgeAddresses {
-    pub l1_shared_default_bridge: Option<Address>,
-    pub l2_shared_default_bridge: Option<Address>,
-    pub l1_erc20_default_bridge: Option<Address>,
-    pub l2_erc20_default_bridge: Option<Address>,
-    pub l1_weth_bridge: Option<Address>,
-    pub l2_weth_bridge: Option<Address>,
-    pub l2_legacy_shared_bridge: Option<Address>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BaseSystemContractsHashes {
-    pub bootloader: B256,
-    pub default_aa: B256,
-    pub evm_emulator: Option<B256>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum BlockStatus {
-    Sealed,
-    Verified,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BlockDetailsBase {
-    pub timestamp: u64,
-    pub l1_tx_count: u64,
-    pub l2_tx_count: u64,
-    pub root_hash: Option<B256>,
-    pub status: BlockStatus,
-    pub commit_tx_hash: Option<B256>,
-    pub committed_at: Option<DateTime<Utc>>,
-    pub prove_tx_hash: Option<B256>,
-    pub proven_at: Option<DateTime<Utc>>,
-    pub execute_tx_hash: Option<B256>,
-    pub executed_at: Option<DateTime<Utc>>,
-    pub l1_gas_price: U256,
-    pub l2_fair_gas_price: U256,
-    pub fair_pubdata_price: Option<U256>,
-    pub base_system_contracts_hashes: BaseSystemContractsHashes,
-}
-/// Response type for `zks_getBlockDetails`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct BlockDetails {
-    pub number: u64,
-    pub l1_batch_number: u64,
-    pub operator_address: Address,
-    pub protocol_version: Option<String>,
-    #[serde(flatten)]
-    pub base: BlockDetailsBase,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum TransactionStatus {
-    Pending,
-    Included,
-    Verified,
-    Failed,
-}
-
-/// Response type for `zks_getTransactionDetails`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TransactionDetails {
-    pub is_l1_originated: bool,
-    pub status: TransactionStatus,
-    pub fee: U256,
-    pub gas_per_pubdata: U256,
-    pub initiator_address: Address,
-    pub received_at: String,
-    pub eth_commit_tx_hash: Option<B256>,
-    pub eth_prove_tx_hash: Option<B256>,
-    pub eth_execute_tx_hash: Option<B256>,
-}
-
-/// Response type for `zks_getL1BatchDetails`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct L1BatchDetails {
-    pub number: u64,
-    #[serde(flatten)]
-    pub base: BlockDetailsBase,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FeeModelConfigV2 {
-    pub minimal_l2_gas_price: U256,
-    pub compute_overhead_part: f64,
-    pub pubdata_overhead_part: f64,
-    pub batch_overhead_l1_gas: U256,
-    pub max_gas_per_batch: U256,
-    pub max_pubdata_per_batch: U256,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BaseTokenConversionRatio {
-    pub numerator: u64,
-    pub denominator: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FeeParamsV2 {
-    config: FeeModelConfigV2,
-    l1_gas_price: U256,
-    l1_pubdata_price: U256,
-    conversion_ratio: BaseTokenConversionRatio,
-}
-
-/// Response type for `zks_getFeeParams`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum FeeParams {
-    V2(FeeParamsV2),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct L1VerifierConfig {
-    pub recursion_scheduler_level_vk_hash: B256,
-}
-
-/// Response type for `zks_getProtocolVersion`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProtocolVersion {
-    #[serde(rename = "minorVersion")]
-    pub minor_version: Option<u16>,
-    pub timestamp: u64,
-    pub verification_keys_hashes: Option<L1VerifierConfig>,
-    pub base_system_contracts: Option<BaseSystemContractsHashes>,
-    #[serde(rename = "bootloaderCodeHash")]
-    pub bootloader_code_hash: Option<B256>,
-    #[serde(rename = "defaultAccountCodeHash")]
-    pub default_account_code_hash: Option<B256>,
-    #[serde(rename = "evmSimulatorCodeHash")]
-    pub evm_emulator_code_hash: Option<B256>,
-    #[serde(rename = "l2SystemUpgradeTxHash")]
-    pub l2_system_upgrade_tx_hash: Option<B256>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StorageProof {
-    pub key: B256,
-    pub proof: Vec<B256>,
-    pub value: B256,
-    pub index: u64,
-}
-
-/// Response type for `zks_getProof`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Proof {
-    pub address: Address,
-    pub storage_proof: Vec<StorageProof>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StorageLog {
-    pub address: Address,
-    pub key: U256,
-    pub written_value: U256,
-}
-
-/// A log produced by a transaction.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Log {
-    pub address: Address,
-    pub topics: Vec<B256>,
-    pub data: Bytes,
-    pub block_hash: Option<B256>,
-    pub block_number: Option<U64>,
-    pub l1_batch_number: Option<U64>,
-    pub transaction_hash: Option<B256>,
-    pub transaction_index: Option<U64>,
-    pub log_index: Option<U64>,
-    pub transaction_log_index: Option<U64>,
-    pub log_type: Option<String>,
-    pub removed: Option<bool>,
-    pub block_timestamp: Option<U64>,
-}
-
-/// Response type for `zks_sendRawTransactionWithDetailedOutput`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TransactionDetailedResult {
-    pub transaction_hash: B256,
-    pub storage_logs: Vec<StorageLog>,
-    pub events: Vec<Log>,
-}
-
-/// Response type for `zks_getConfirmedTokens`.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Token {
-    pub l1_address: Address,
-    pub l2_address: Address,
-    pub name: String,
-    pub symbol: String,
-    pub decimals: u8,
-}
-
-/// Response type for `zks_getL2ToL1LogProof`.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct L2ToL1LogProof {
-    /// The merkle path for the leaf.
-    pub proof: Vec<B256>,
-    /// The id of the leaf in a tree.
-    pub id: u32,
-    /// The root of the tree.
-    pub root: B256,
-}
-
 type GetMsgProofRequest = (u64, Address, B256, Option<usize>);
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Execute {
-    pub contract_address: Option<Address>,
-    pub calldata: Bytes,
-    pub value: U256,
-    /// Factory dependencies: list of contract bytecodes associated with the deploy transaction.
-    pub factory_deps: Vec<Bytes>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct InputData {
-    pub hash: B256,
-    pub data: Bytes,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct L2TxCommonData {
-    pub nonce: u32,
-    pub fee: Eip712Fee,
-    pub initiator_address: Address,
-    pub signature: Bytes,
-    pub transaction_type: String,
-    pub input: Option<InputData>,
-    pub paymaster_params: PaymasterParams,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub enum ExecuteTransactionCommon {
-    L2(L2TxCommonData),
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Transaction {
-    pub common_data: ExecuteTransactionCommon,
-    pub execute: Execute,
-    pub received_timestamp_ms: u64,
-    pub raw_bytes: Option<Bytes>,
-}
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -361,17 +82,6 @@ where
             .into()
     }
 
-    /// Lists confirmed tokens.
-    /// Confirmed in the method name means any token bridged to ZKsync Era via the official bridge.
-    ///
-    /// The tokens are returned in alphabetical order by their symbol.
-    /// This means the token id is its position in an alphabetically sorted array of tokens.
-    fn get_confirmed_tokens(&self, from: u32, limit: u8) -> ProviderCall<T, (u32, u8), Vec<Token>> {
-        self.client()
-            .request("zks_getConfirmedTokens", (from, limit))
-            .into()
-    }
-
     /// Gets all account balances for a given address.
     fn get_all_account_balances(
         &self,
@@ -429,7 +139,8 @@ where
             .into()
     }
 
-    /// Lists transactions in a block without processing them.
+    /// Lists transactions in a native encoding (e.g. that has more details, but does not
+    /// adhere to the "common" Web3 Transaction interface).
     fn get_raw_block_transactions(
         &self,
         block_number: u64,
@@ -496,19 +207,6 @@ where
     ) -> ProviderCall<T, (Address, Vec<B256>, u64), Option<Proof>> {
         self.client()
             .request("zks_getProof", (address, keys, l1_batch_number))
-            .into()
-    }
-
-    /// Executes a transaction and returns its hash, storage logs, and events that
-    /// would have been generated if the transaction had already been included in the block.
-    /// The API has a similar behaviour to eth_sendRawTransaction
-    /// but with some extra data returned from it.
-    fn send_raw_transaction_with_detailed_output(
-        &self,
-        tx_bytes: Bytes,
-    ) -> ProviderCall<T, (Bytes,), TransactionDetailedResult> {
-        self.client()
-            .request("zks_sendRawTransactionWithDetailedOutput", (tx_bytes,))
             .into()
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -253,6 +253,8 @@ pub struct L2ToL1LogProof {
     pub root: B256,
 }
 
+type GetMsgProofRequest = (u64, Address, B256, Option<usize>);
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Execute {
@@ -387,7 +389,7 @@ where
         sender: Address,
         msg: B256,
         l2_log_position: Option<usize>,
-    ) -> ProviderCall<T, (u64, Address, B256, Option<usize>), Option<L2ToL1LogProof>> {
+    ) -> ProviderCall<T, GetMsgProofRequest, Option<L2ToL1LogProof>> {
         self.client()
             .request(
                 "zks_getL2ToL1MsgProof",

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,12 +1,15 @@
-use alloy::primitives::{Address, U256, U64};
+use alloy::primitives::{Address, Bytes, B256, U256, U64};
 use alloy::providers::fillers::{ChainIdFiller, JoinFill, NonceFiller, RecommendedFillers};
 use alloy::providers::{Identity, Provider, ProviderBuilder, ProviderCall};
 use alloy::rpc::client::NoParams;
 use alloy::transports::{BoxTransport, Transport};
+use chrono::{DateTime, Utc};
 use fillers::Eip712FeeFiller;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use crate::network::transaction_request::TransactionRequest;
+use crate::network::unsigned_tx::eip712::PaymasterParams;
 use crate::network::Zksync;
 
 pub use self::provider_builder_ext::ProviderBuilderExt;
@@ -31,6 +34,266 @@ pub struct Eip712Fee {
     pub max_priority_fee_per_gas: u128,
 }
 
+/// Response type for `zks_getBridgeContracts`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeAddresses {
+    pub l1_shared_default_bridge: Option<Address>,
+    pub l2_shared_default_bridge: Option<Address>,
+    pub l1_erc20_default_bridge: Option<Address>,
+    pub l2_erc20_default_bridge: Option<Address>,
+    pub l1_weth_bridge: Option<Address>,
+    pub l2_weth_bridge: Option<Address>,
+    pub l2_legacy_shared_bridge: Option<Address>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseSystemContractsHashes {
+    pub bootloader: B256,
+    pub default_aa: B256,
+    pub evm_emulator: Option<B256>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum BlockStatus {
+    Sealed,
+    Verified,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockDetailsBase {
+    pub timestamp: u64,
+    pub l1_tx_count: u64,
+    pub l2_tx_count: u64,
+    pub root_hash: Option<B256>,
+    pub status: BlockStatus,
+    pub commit_tx_hash: Option<B256>,
+    pub committed_at: Option<DateTime<Utc>>,
+    pub prove_tx_hash: Option<B256>,
+    pub proven_at: Option<DateTime<Utc>>,
+    pub execute_tx_hash: Option<B256>,
+    pub executed_at: Option<DateTime<Utc>>,
+    pub l1_gas_price: U256,
+    pub l2_fair_gas_price: U256,
+    pub fair_pubdata_price: Option<U256>,
+    pub base_system_contracts_hashes: BaseSystemContractsHashes,
+}
+/// Response type for `zks_getBlockDetails`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockDetails {
+    pub number: u64,
+    pub l1_batch_number: u64,
+    pub operator_address: Address,
+    pub protocol_version: Option<String>,
+    #[serde(flatten)]
+    pub base: BlockDetailsBase,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransactionStatus {
+    Pending,
+    Included,
+    Verified,
+    Failed,
+}
+
+/// Response type for `zks_getTransactionDetails`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionDetails {
+    pub is_l1_originated: bool,
+    pub status: TransactionStatus,
+    pub fee: U256,
+    pub gas_per_pubdata: U256,
+    pub initiator_address: Address,
+    pub received_at: String,
+    pub eth_commit_tx_hash: Option<B256>,
+    pub eth_prove_tx_hash: Option<B256>,
+    pub eth_execute_tx_hash: Option<B256>,
+}
+
+/// Response type for `zks_getL1BatchDetails`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct L1BatchDetails {
+    pub number: u64,
+    #[serde(flatten)]
+    pub base: BlockDetailsBase,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeeModelConfigV2 {
+    pub minimal_l2_gas_price: U256,
+    pub compute_overhead_part: f64,
+    pub pubdata_overhead_part: f64,
+    pub batch_overhead_l1_gas: U256,
+    pub max_gas_per_batch: U256,
+    pub max_pubdata_per_batch: U256,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseTokenConversionRatio {
+    pub numerator: u64,
+    pub denominator: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeeParamsV2 {
+    config: FeeModelConfigV2,
+    l1_gas_price: U256,
+    l1_pubdata_price: U256,
+    conversion_ratio: BaseTokenConversionRatio,
+}
+
+/// Response type for `zks_getFeeParams`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FeeParams {
+    V2(FeeParamsV2),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct L1VerifierConfig {
+    pub recursion_scheduler_level_vk_hash: B256,
+}
+
+/// Response type for `zks_getProtocolVersion`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProtocolVersion {
+    #[serde(rename = "minorVersion")]
+    pub minor_version: Option<u16>,
+    pub timestamp: u64,
+    pub verification_keys_hashes: Option<L1VerifierConfig>,
+    pub base_system_contracts: Option<BaseSystemContractsHashes>,
+    #[serde(rename = "bootloaderCodeHash")]
+    pub bootloader_code_hash: Option<B256>,
+    #[serde(rename = "defaultAccountCodeHash")]
+    pub default_account_code_hash: Option<B256>,
+    #[serde(rename = "evmSimulatorCodeHash")]
+    pub evm_emulator_code_hash: Option<B256>,
+    #[serde(rename = "l2SystemUpgradeTxHash")]
+    pub l2_system_upgrade_tx_hash: Option<B256>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageProof {
+    pub key: B256,
+    pub proof: Vec<B256>,
+    pub value: B256,
+    pub index: u64,
+}
+
+/// Response type for `zks_getProof`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Proof {
+    pub address: Address,
+    pub storage_proof: Vec<StorageProof>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageLog {
+    pub address: Address,
+    pub key: U256,
+    pub written_value: U256,
+}
+
+/// A log produced by a transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Log {
+    pub address: Address,
+    pub topics: Vec<B256>,
+    pub data: Bytes,
+    pub block_hash: Option<B256>,
+    pub block_number: Option<U64>,
+    pub l1_batch_number: Option<U64>,
+    pub transaction_hash: Option<B256>,
+    pub transaction_index: Option<U64>,
+    pub log_index: Option<U64>,
+    pub transaction_log_index: Option<U64>,
+    pub log_type: Option<String>,
+    pub removed: Option<bool>,
+    pub block_timestamp: Option<U64>,
+}
+
+/// Response type for `zks_sendRawTransactionWithDetailedOutput`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionDetailedResult {
+    pub transaction_hash: B256,
+    pub storage_logs: Vec<StorageLog>,
+    pub events: Vec<Log>,
+}
+
+/// Response type for `zks_getConfirmedTokens`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Token {
+    pub l1_address: Address,
+    pub l2_address: Address,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+/// Response type for `zks_getL2ToL1LogProof`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct L2ToL1LogProof {
+    /// The merkle path for the leaf.
+    pub proof: Vec<B256>,
+    /// The id of the leaf in a tree.
+    pub id: u32,
+    /// The root of the tree.
+    pub root: B256,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Execute {
+    pub contract_address: Option<Address>,
+    pub calldata: Bytes,
+    pub value: U256,
+    /// Factory dependencies: list of contract bytecodes associated with the deploy transaction.
+    pub factory_deps: Vec<Bytes>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InputData {
+    pub hash: B256,
+    pub data: Bytes,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct L2TxCommonData {
+    pub nonce: u32,
+    pub fee: Eip712Fee,
+    pub initiator_address: Address,
+    pub signature: Bytes,
+    pub transaction_type: String,
+    pub input: Option<InputData>,
+    pub paymaster_params: PaymasterParams,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum ExecuteTransactionCommon {
+    L2(L2TxCommonData),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Transaction {
+    pub common_data: ExecuteTransactionCommon,
+    pub execute: Execute,
+    pub received_timestamp_ms: u64,
+    pub raw_bytes: Option<Bytes>,
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait ZksyncProvider<T = BoxTransport>: Provider<T, Zksync>
@@ -43,7 +306,7 @@ where
     }
 
     /// Gets the address of the testnet paymaster ZKsync contract on L2, if it's present on the network.
-    fn get_testnet_paymaster(&self) -> ProviderCall<T, NoParams, Address> {
+    fn get_testnet_paymaster(&self) -> ProviderCall<T, NoParams, Option<Address>> {
         self.client()
             .request_noparams("zks_getTestnetPaymaster")
             .into()
@@ -59,12 +322,192 @@ where
         self.client().request_noparams("zks_L1BatchNumber").into()
     }
 
-    /// Estimate transaction gas for EIP712 transactions.
+    /// Estimates transaction gas for EIP712 transactions.
     fn estimate_fee(
         &self,
         tx: TransactionRequest,
     ) -> ProviderCall<T, (TransactionRequest,), Eip712Fee> {
         self.client().request("zks_estimateFee", (tx,)).into()
+    }
+
+    /// Estimates the gas required for an L1 to L2 transaction.
+    fn estimate_gas_l1_to_l2(
+        &self,
+        tx: TransactionRequest,
+    ) -> ProviderCall<T, (TransactionRequest,), U256> {
+        self.client().request("zks_estimateGasL1ToL2", (tx,)).into()
+    }
+
+    /// Retrieves the bridge hub contract address.
+    fn get_bridgehub_contract(&self) -> ProviderCall<T, NoParams, Option<Address>> {
+        self.client()
+            .request_noparams("zks_getBridgehubContract")
+            .into()
+    }
+
+    /// Retrieves the addresses of canonical bridge contracts for ZKsync Era.
+    fn get_bridge_contracts(&self) -> ProviderCall<T, NoParams, BridgeAddresses> {
+        self.client()
+            .request_noparams("zks_getBridgeContracts")
+            .into()
+    }
+
+    /// Retrieves the L1 base token address.
+    fn get_base_token_l1_address(&self) -> ProviderCall<T, NoParams, Address> {
+        self.client()
+            .request_noparams("zks_getBaseTokenL1Address")
+            .into()
+    }
+
+    /// Lists confirmed tokens.
+    /// Confirmed in the method name means any token bridged to ZKsync Era via the official bridge.
+    ///
+    /// The tokens are returned in alphabetical order by their symbol.
+    /// This means the token id is its position in an alphabetically sorted array of tokens.
+    fn get_confirmed_tokens(&self, from: u32, limit: u8) -> ProviderCall<T, (u32, u8), Vec<Token>> {
+        self.client()
+            .request("zks_getConfirmedTokens", (from, limit))
+            .into()
+    }
+
+    /// Gets all account balances for a given address.
+    fn get_all_account_balances(
+        &self,
+        address: Address,
+    ) -> ProviderCall<T, (Address,), HashMap<Address, U256>> {
+        self.client()
+            .request("zks_getAllAccountBalances", (address,))
+            .into()
+    }
+
+    /// Retrieves the proof for an L2 to L1 message.
+    fn get_l2_to_l1_msg_proof(
+        &self,
+        block_number: u64,
+        sender: Address,
+        msg: B256,
+        l2_log_position: Option<usize>,
+    ) -> ProviderCall<T, (u64, Address, B256, Option<usize>), Option<L2ToL1LogProof>> {
+        self.client()
+            .request(
+                "zks_getL2ToL1MsgProof",
+                (block_number, sender, msg, l2_log_position),
+            )
+            .into()
+    }
+
+    /// Retrieves the log proof for an L2 to L1 transaction.
+    fn get_l2_to_l1_log_proof(
+        &self,
+        tx_hash: B256,
+        index: Option<usize>,
+    ) -> ProviderCall<T, (B256, Option<usize>), Option<L2ToL1LogProof>> {
+        self.client()
+            .request("zks_getL2ToL1LogProof", (tx_hash, index))
+            .into()
+    }
+
+    /// Retrieves details for a given block.
+    fn get_block_details(
+        &self,
+        block_number: u64,
+    ) -> ProviderCall<T, (u64,), Option<BlockDetails>> {
+        self.client()
+            .request("zks_getBlockDetails", (block_number,))
+            .into()
+    }
+
+    /// Retrieves details for a given transaction.
+    fn get_transaction_details(
+        &self,
+        tx_hash: B256,
+    ) -> ProviderCall<T, (B256,), Option<TransactionDetails>> {
+        self.client()
+            .request("zks_getTransactionDetails", (tx_hash,))
+            .into()
+    }
+
+    /// Lists transactions in a block without processing them.
+    fn get_raw_block_transactions(
+        &self,
+        block_number: u64,
+    ) -> ProviderCall<T, (u64,), Vec<Transaction>> {
+        self.client()
+            .request("zks_getRawBlockTransactions", (block_number,))
+            .into()
+    }
+
+    /// Retrieves details for a given L1 batch.
+    fn get_l1_batch_details(
+        &self,
+        l1_batch_number: u64,
+    ) -> ProviderCall<T, (u64,), Option<L1BatchDetails>> {
+        self.client()
+            .request("zks_getL1BatchDetails", (l1_batch_number,))
+            .into()
+    }
+
+    /// Retrieves the bytecode of a transaction by its hash.
+    fn get_bytecode_by_hash(&self, tx_hash: B256) -> ProviderCall<T, (B256,), Option<Bytes>> {
+        self.client()
+            .request("zks_getBytecodeByHash", (tx_hash,))
+            .into()
+    }
+
+    /// Returns the range of blocks contained within a batch given by the batch number.
+    fn get_l1_batch_block_range(
+        &self,
+        l1_batch_number: u64,
+    ) -> ProviderCall<T, (u64,), Option<(U64, U64)>> {
+        self.client()
+            .request("zks_getL1BatchBlockRange", (l1_batch_number,))
+            .into()
+    }
+
+    /// Retrieves the current L1 gas price.
+    fn get_l1_gas_price(&self) -> ProviderCall<T, NoParams, U256> {
+        self.client().request_noparams("zks_getL1GasPrice").into()
+    }
+
+    /// Retrieves the current fee parameters.
+    fn get_fee_params(&self) -> ProviderCall<T, NoParams, FeeParams> {
+        self.client().request_noparams("zks_getFeeParams").into()
+    }
+
+    /// Retrieves the current fee parameters.
+    fn get_protocol_version(
+        &self,
+        version_id: Option<u16>,
+    ) -> ProviderCall<T, (Option<u16>,), Option<ProtocolVersion>> {
+        self.client()
+            .request("zks_getProtocolVersion", (version_id,))
+            .into()
+    }
+
+    /// Generates Merkle proofs for one or more storage values associated with a specific account,
+    /// accompanied by a proof of their authenticity. It verifies that these values remain unaltered.
+    fn get_proof(
+        &self,
+        address: Address,
+        keys: Vec<B256>,
+        l1_batch_number: u64,
+    ) -> ProviderCall<T, (Address, Vec<B256>, u64), Option<Proof>> {
+        self.client()
+            .request("zks_getProof", (address, keys, l1_batch_number))
+            .into()
+    }
+
+    /// Executes a transaction and returns its hash, storage logs, and events that
+    /// would have been generated if the transaction had already been included in the block.
+    /// The API has a similar behaviour to eth_sendRawTransaction
+    /// but with some extra data returned from it.
+    fn send_raw_transaction_with_detailed_output(
+        &self,
+        tx_bytes: Bytes,
+    ) -> ProviderCall<T, (Bytes,), TransactionDetailedResult> {
+        self.client()
+            .request("zks_sendRawTransactionWithDetailedOutput", (tx_bytes,))
+            .into()
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,335 @@
+use crate::network::unsigned_tx::eip712::PaymasterParams;
+use alloy::primitives::{Address, Bytes, B256, U256, U64};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Response type for `zks_estimateFee`.
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct Eip712Fee {
+    /// Amount of gas to be spent on the transaction.
+    #[serde(with = "alloy::serde::quantity")]
+    pub gas_limit: u64,
+    /// Maximum gas user agrees to spend on a single pubdata byte published to L1.
+    pub gas_per_pubdata_limit: U256,
+    /// EIP-1559 gas price.
+    #[serde(with = "alloy::serde::quantity")]
+    pub max_fee_per_gas: u128,
+    /// EIP-1559 tip.
+    #[serde(with = "alloy::serde::quantity")]
+    pub max_priority_fee_per_gas: u128,
+}
+
+/// Response type for `zks_getBridgeContracts`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeAddresses {
+    pub l1_shared_default_bridge: Option<Address>,
+    pub l2_shared_default_bridge: Option<Address>,
+    pub l1_erc20_default_bridge: Option<Address>,
+    pub l2_erc20_default_bridge: Option<Address>,
+    pub l1_weth_bridge: Option<Address>,
+    pub l2_weth_bridge: Option<Address>,
+    pub l2_legacy_shared_bridge: Option<Address>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseSystemContractsHashes {
+    pub bootloader: B256,
+    pub default_aa: B256,
+    pub evm_emulator: Option<B256>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum BlockStatus {
+    Sealed,
+    Verified,
+}
+
+/// Response type for `zks_getBlockDetails`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockDetails {
+    pub number: u64,
+    pub l1_batch_number: u64,
+    pub operator_address: Address,
+    pub protocol_version: Option<String>,
+    pub timestamp: u64,
+    pub l1_tx_count: u64,
+    pub l2_tx_count: u64,
+    pub root_hash: Option<B256>,
+    pub status: BlockStatus,
+    pub commit_tx_hash: Option<B256>,
+    pub committed_at: Option<DateTime<Utc>>,
+    pub prove_tx_hash: Option<B256>,
+    pub proven_at: Option<DateTime<Utc>>,
+    pub execute_tx_hash: Option<B256>,
+    pub executed_at: Option<DateTime<Utc>>,
+    pub l1_gas_price: U256,
+    pub l2_fair_gas_price: U256,
+    pub fair_pubdata_price: Option<U256>,
+    pub base_system_contracts_hashes: BaseSystemContractsHashes,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransactionStatus {
+    Pending,
+    Included,
+    Verified,
+    Failed,
+}
+
+/// Response type for `zks_getTransactionDetails`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionDetails {
+    pub is_l1_originated: bool,
+    pub status: TransactionStatus,
+    pub fee: U256,
+    pub gas_per_pubdata: U256,
+    pub initiator_address: Address,
+    pub received_at: String,
+    pub eth_commit_tx_hash: Option<B256>,
+    pub eth_prove_tx_hash: Option<B256>,
+    pub eth_execute_tx_hash: Option<B256>,
+}
+
+/// Response type for `zks_getL1BatchDetails`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct L1BatchDetails {
+    pub number: u64,
+    pub timestamp: u64,
+    pub l1_tx_count: u64,
+    pub l2_tx_count: u64,
+    pub root_hash: Option<B256>,
+    pub status: BlockStatus,
+    pub commit_tx_hash: Option<B256>,
+    pub committed_at: Option<DateTime<Utc>>,
+    pub prove_tx_hash: Option<B256>,
+    pub proven_at: Option<DateTime<Utc>>,
+    pub execute_tx_hash: Option<B256>,
+    pub executed_at: Option<DateTime<Utc>>,
+    pub l1_gas_price: U256,
+    pub l2_fair_gas_price: U256,
+    pub fair_pubdata_price: Option<U256>,
+    pub base_system_contracts_hashes: BaseSystemContractsHashes,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeeModelConfigV2 {
+    pub minimal_l2_gas_price: U256,
+    pub compute_overhead_part: f64,
+    pub pubdata_overhead_part: f64,
+    pub batch_overhead_l1_gas: U256,
+    pub max_gas_per_batch: U256,
+    pub max_pubdata_per_batch: U256,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseTokenConversionRatio {
+    pub numerator: u64,
+    pub denominator: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeeParamsV2 {
+    config: FeeModelConfigV2,
+    l1_gas_price: U256,
+    l1_pubdata_price: U256,
+    conversion_ratio: BaseTokenConversionRatio,
+}
+
+/// Response type for `zks_getFeeParams`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FeeParams {
+    V2(FeeParamsV2),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct L1VerifierConfig {
+    pub recursion_scheduler_level_vk_hash: B256,
+}
+
+/// Response type for `zks_getProtocolVersion`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProtocolVersion {
+    #[serde(rename = "minorVersion")]
+    pub minor_version: Option<u16>,
+    pub timestamp: u64,
+    pub verification_keys_hashes: Option<L1VerifierConfig>,
+    pub base_system_contracts: Option<BaseSystemContractsHashes>,
+    #[serde(rename = "bootloaderCodeHash")]
+    pub bootloader_code_hash: Option<B256>,
+    #[serde(rename = "defaultAccountCodeHash")]
+    pub default_account_code_hash: Option<B256>,
+    #[serde(rename = "evmSimulatorCodeHash")]
+    pub evm_emulator_code_hash: Option<B256>,
+    #[serde(rename = "l2SystemUpgradeTxHash")]
+    pub l2_system_upgrade_tx_hash: Option<B256>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageProof {
+    pub key: B256,
+    pub proof: Vec<B256>,
+    pub value: B256,
+    pub index: u64,
+}
+
+/// Response type for `zks_getProof`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Proof {
+    pub address: Address,
+    pub storage_proof: Vec<StorageProof>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageLog {
+    pub address: Address,
+    pub key: U256,
+    pub written_value: U256,
+}
+
+/// A log produced by a transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Log {
+    pub address: Address,
+    pub topics: Vec<B256>,
+    pub data: Bytes,
+    pub block_hash: Option<B256>,
+    pub block_number: Option<U64>,
+    pub l1_batch_number: Option<U64>,
+    pub transaction_hash: Option<B256>,
+    pub transaction_index: Option<U64>,
+    pub log_index: Option<U64>,
+    pub transaction_log_index: Option<U64>,
+    pub log_type: Option<String>,
+    pub removed: Option<bool>,
+    pub block_timestamp: Option<U64>,
+}
+
+/// Response type for `zks_getL2ToL1LogProof`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct L2ToL1LogProof {
+    /// The merkle path for the leaf.
+    pub proof: Vec<B256>,
+    /// The id of the leaf in a tree.
+    pub id: u32,
+    /// The root of the tree.
+    pub root: B256,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Execute {
+    pub contract_address: Option<Address>,
+    pub calldata: Bytes,
+    pub value: U256,
+    /// Factory dependencies: list of contract bytecodes associated with the deploy transaction.
+    pub factory_deps: Vec<Bytes>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InputData {
+    pub hash: B256,
+    pub data: Bytes,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[repr(u8)]
+pub enum OpProcessingType {
+    Common = 0,
+    OnlyRollup = 1,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+#[repr(u8)]
+pub enum PriorityQueueType {
+    #[default]
+    Deque = 0,
+    HeapBuffer = 1,
+    Heap = 2,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct L1TxCommonData {
+    /// Sender of the transaction.
+    pub sender: Address,
+    /// Unique ID of the priority operation.
+    pub serial_id: u64,
+    /// Additional payment to the operator as an incentive to perform the operation. The contract uses a value of 192 bits.
+    pub layer_2_tip_fee: U256,
+    /// The total cost the sender paid for the transaction.
+    pub full_fee: U256,
+    /// The maximal fee per gas to be used for L1->L2 transaction
+    pub max_fee_per_gas: U256,
+    /// The maximum number of gas that a transaction can spend at a price of gas equals 1.
+    pub gas_limit: U256,
+    /// The maximum number of gas per 1 byte of pubdata.
+    pub gas_per_pubdata_limit: U256,
+    /// Indicator that the operation can interact with Rollup and Porter trees, or only with Rollup.
+    pub op_processing_type: OpProcessingType,
+    /// Priority operations queue type.
+    pub priority_queue_type: PriorityQueueType,
+    /// Tx hash of the transaction in the ZKsync network. Calculated as the encoded transaction data hash.
+    pub canonical_tx_hash: B256,
+    /// The amount of ETH that should be minted with this transaction
+    pub to_mint: U256,
+    /// The recipient of the refund of the transaction
+    pub refund_recipient: Address,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct L2TxCommonData {
+    pub nonce: u32,
+    pub fee: Eip712Fee,
+    pub initiator_address: Address,
+    pub signature: Bytes,
+    pub transaction_type: String,
+    pub input: Option<InputData>,
+    pub paymaster_params: PaymasterParams,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ProtocolUpgradeTxCommonData {
+    /// Sender of the transaction.
+    pub sender: Address,
+    /// ID of the upgrade.
+    pub upgrade_id: String,
+    /// The maximal fee per gas to be used for L1->L2 transaction
+    pub max_fee_per_gas: U256,
+    /// The maximum number of gas that a transaction can spend at a price of gas equals 1.
+    pub gas_limit: U256,
+    /// The maximum number of gas per 1 byte of pubdata.
+    pub gas_per_pubdata_limit: U256,
+    /// Block in which Ethereum transaction was included.
+    pub eth_block: u64,
+    /// Tx hash of the transaction in the ZKsync network. Calculated as the encoded transaction data hash.
+    pub canonical_tx_hash: B256,
+    /// The amount of ETH that should be minted with this transaction
+    pub to_mint: U256,
+    /// The recipient of the refund of the transaction
+    pub refund_recipient: Address,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum ExecuteTransactionCommon {
+    L1(L1TxCommonData),
+    L2(L2TxCommonData),
+    ProtocolUpgrade(ProtocolUpgradeTxCommonData),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Transaction {
+    pub common_data: ExecuteTransactionCommon,
+    pub execute: Execute,
+    pub received_timestamp_ms: u64,
+    pub raw_bytes: Option<Bytes>,
+}


### PR DESCRIPTION
Add the following zks namespace methods to zksync provider:
* `zks_estimateGasL1ToL2`
* `zks_getBridgehubContract`
* `zks_getBridgeContracts`
* `zks_getBaseTokenL1Address`
* `zks_getAllAccountBalances`
* `zks_getL2ToL1MsgProof`
* `zks_getL2ToL1LogProof`
* `zks_getBlockDetails`
* `zks_getTransactionDetails`
* `zks_getRawBlockTransactions`
* `zks_getL1BatchDetails`
* `zks_getBytecodeByHash`
* `zks_getL1BatchBlockRange`
* `zks_getL1GasPrice`
* `zks_getFeeParams`
* `zks_getProtocolVersion`
* `zks_getProof`