### PR TITLE
feat: support alloy v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,9 +38,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8ebf106e84a1c37f86244df7da0c7587e697b71a0d565cce079449b85ac6f8"
+checksum = "b5b524b8c28a7145d1fe4950f84360b5de3e307601679ff0558ddc20ea229399"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed961a48297c732a5d97ee321aa8bb5009ecadbcb077d8bec90cb54e651629"
+checksum = "ae09ffd7c29062431dd86061deefe4e3c6f07fa0d674930095f8dcedb0baf02c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -84,14 +84,15 @@ dependencies = [
  "auto_impl",
  "c-kzg",
  "derive_more",
+ "k256",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460ab80ce4bda1c80bcf96fe7460520476f2c7b734581c6567fac2708e2a60ef"
+checksum = "66430a72d5bf5edead101c8c2f0a24bada5ec9f3cf9909b3e08b6d6899b4803e"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -110,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce854562e7cafd5049189d0268d6e5cba05fe6c9cb7c6f8126a79b94800629c"
+checksum = "9c8316d83e590f4163b221b8180008f302bda5cf5451202855cdd323e588849c"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -123,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b499852e1d0e9b8c6db0f24c48998e647c0d5762a01090f955106a7700e4611"
+checksum = "ef2364c782a245cf8725ea6dbfca5f530162702b5d685992ea03ce64529136cc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -151,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ffc577390ce50234e02d841214b3dc0bea6aaaae8e04bbf3cb82e9a45da9eb"
+checksum = "5f6cee6a35793f3db8a5ffe60e86c695f321d081a567211245f503e8c498fce8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -164,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69e06cf9c37be824b9d26d6d101114fdde6af0c87de2828b414c05c4b3daa71"
+checksum = "5b6aa3961694b30ba53d41006131a2fca3bdab22e4c344e46db2c639e7c2dfdd"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -182,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde15e14944a88bd6a57d325e9a49b75558746fe16aaccc79713ae50a6a9574c"
+checksum = "e53f7877ded3921d18a0a9556d55bedf84535567198c9edab2aa23106da91855"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -193,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a438d4486b5d525df3b3004188f9d5cd1d65cd30ecc41e5a3ccef6f6342e8af9"
+checksum = "b84c506bf264110fa7e90d9924f742f40ef53c6572ea56a0b0bd714a567ed389"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -205,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5979e0d5a7bf9c7eb79749121e8256e59021af611322aee56e77e20776b4b3"
+checksum = "3694b7e480728c0b3e228384f223937f14c10caef5a4c766021190fc8f283d35"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -219,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "204237129086ce5dc17a58025e93739b01b45313841f98fa339eb1d780511e57"
+checksum = "ea94b8ceb5c75d7df0a93ba0acc53b55a22b47b532b600a800a87ef04eb5b0b4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -235,14 +236,16 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514f70ee2a953db21631cd817b13a1571474ec77ddc03d47616d5e8203489fde"
+checksum = "df9f3e281005943944d15ee8491534a1c7b3cbf7a7de26f8c433b842b93eb5f9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -253,16 +256,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260d3ff3bff0bb84599f032a2f2c6828180b0ea0cd41fdaf44f39cef3ba41861"
+checksum = "9fce5dbd6a4f118eecc4719eaa9c7ffc31c315e6c5ccde3642db927802312425"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
- "hashbrown 0.14.5",
+ "foldhash",
+ "hashbrown 0.15.0",
  "hex-literal",
  "indexmap",
  "itoa",
@@ -280,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4814d141ede360bb6cd1b4b064f1aab9de391e7c4d0d4d50ac89ea4bc1e25fbd"
+checksum = "40c1f9eede27bf4c13c099e8e64d54efd7ce80ef6ea47478aa75d5d74e2dba3b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -320,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba46eb69ddf7a9925b81f15229cb74658e6eebe5dd30a5b74e2cd040380573"
+checksum = "90f1f34232f77341076541c405482e4ae12f0ee7153d8f9969fc1691201b2247"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -339,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -350,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
+checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -361,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc2bd1e7403463a5f2c61e955bcc9d3072b63aa177442b0f9aa6a6d22a941e3"
+checksum = "374dbe0dc3abdc2c964f36b3d3edf9cdb3db29d16bda34aa123f03d810bec1dd"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -387,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea9bf1abdd506f985a53533f5ac01296bcd6102c5e139bbc5d40bc468d2c916"
+checksum = "c74832aa474b670309c20fffc2a869fa141edab7c79ff7963fad0a08de60bae1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -400,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886d22d41992287a235af2f3af4299b5ced2bcafb81eb835572ad35747476946"
+checksum = "3f56294dce86af23ad6ee8df46cf8b0d292eb5d1ff67dc88a0886051e32b1faf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -416,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b034779a4850b4b03f5be5ea674a1cf7d746b2da762b34d1860ab45e48ca27"
+checksum = "a8a477281940d82d29315846c7216db45b15e90bcd52309da9f54bcf7ad94a11"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -435,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028e72eaa9703e4882344983cfe7636ce06d8cce104a78ea62fd19b46659efc4"
+checksum = "4dfa4a7ccf15b2492bb68088692481fd6b2604ccbee1d0d6c44c21427ae4df83"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -446,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592c185d7100258c041afac51877660c7bf6213447999787197db4842f0e938e"
+checksum = "2e10aec39d60dc27edcac447302c7803d2371946fb737245320a05b78eb2fafd"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -460,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6614f02fc1d5b079b2a4a5320018317b506fd0a6d67c1fd5542a71201724986c"
+checksum = "d8396f6dff60700bc1d215ee03d86ff56de268af96e2bf833a14d0bafcab9882"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -476,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e7f6e8fe5b443f82b3f1e15abfa191128f71569148428e49449d01f6f49e8b"
+checksum = "9343289b4a7461ed8bab8618504c995c049c082b70c7332efd7b32125633dc05"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -490,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b96ce28d2fde09abb6135f410c41fad670a3a770b6776869bd852f1df102e6f"
+checksum = "4222d70bec485ceccc5d8fd4f2909edd65b5d5e43d4aca0b5dcee65d519ae98f"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -509,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906746396a8296537745711630d9185746c0b50c033d5e9d18b0a6eba3d53f90"
+checksum = "2e17f2677369571b976e51ea1430eb41c3690d344fef567b840bfc0b01b6f83a"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -526,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc85178909a49c8827ffccfc9103a7ce1767ae66a801b69bdc326913870bf8e6"
+checksum = "aa64d80ae58ffaafdff9d5d84f58d03775f66c84433916dc9a64ed16af5755da"
 dependencies = [
  "serde",
  "winnow",
@@ -536,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86a533ce22525969661b25dfe296c112d35eb6861f188fd284f8bd4bb3842ae"
+checksum = "6520d427d4a8eb7aa803d852d7a52ceb0c519e784c292f64bb339e636918cf27"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -549,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be77579633ebbc1266ae6fd7694f75c408beb1aeb6865d0b18f22893c265a061"
+checksum = "f99acddb34000d104961897dbb0240298e8b775a7efffb9fda2a1a3efedd65b3"
 dependencies = [
  "alloy-json-rpc",
  "base64",
@@ -569,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd1a5d0827939847983b46f2f79510361f901dc82f8e3c38ac7397af142c6e"
+checksum = "5dc013132e34eeadaa0add7e74164c1503988bfba8bae885b32e0918ba85a8a6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -584,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8073d1186bfeeb8fbdd1292b6f1a0731f3aed8e21e1463905abfae0b96a887a6"
+checksum = "063edc0660e81260653cc6a95777c29d54c2543a668aa5da2359fb450d25a1ba"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -603,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.5.4"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f27837bb4a1d6c83a28231c94493e814882f0e9058648a97e908a5f3fc9fcf"
+checksum = "abd170e600801116d5efe64f74a4fc073dbbb35c807013a7d0a388742aeebba0"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1312,6 +1316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,7 +1524,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -1522,6 +1531,10 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -2864,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab661c8148c2261222a4d641ad5477fd4bea79406a99056096a0b41b35617a5"
+checksum = "f76fe0a3e1476bdaa0775b9aec5b869ed9520c2b2fedfe9c6df3618f8ea6290b"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -3364,9 +3377,9 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasmtimer"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
+checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
 dependencies = [
  "futures",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-zksync"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-zksync"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Igor Aleksanov <popzxc@yandex.ru>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "ZKsync network implementation for alloy"
 
 [dependencies]
-alloy = { version = "0.5", features = ["full", "rlp", "serde", "sol-types"] } # TODO: Set features granularly?
+alloy = { version = "0.6", features = ["full", "rlp", "serde", "sol-types"] } # TODO: Set features granularly?
 async-trait = "0.1.80"
 chrono = { version = "0.4.38", features = ["serde"] }
 futures-utils-wasm = "0.1.0"

--- a/src/network/header.rs
+++ b/src/network/header.rs
@@ -1,11 +1,16 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Header {
     #[serde(flatten)]
     inner: alloy::consensus::Header,
 }
 
+impl Header {
+    pub fn hash_slow(&self) -> alloy::primitives::B256 {
+        self.inner.hash_slow()
+    }
+}
 impl alloy::consensus::BlockHeader for Header {
     fn parent_hash(&self) -> alloy::primitives::B256 {
         self.inner.parent_hash()
@@ -59,11 +64,11 @@ impl alloy::consensus::BlockHeader for Header {
         self.inner.timestamp()
     }
 
-    fn mix_hash(&self) -> alloy::primitives::B256 {
+    fn mix_hash(&self) -> Option<alloy::primitives::B256> {
         self.inner.mix_hash()
     }
 
-    fn nonce(&self) -> alloy::primitives::B64 {
+    fn nonce(&self) -> Option<alloy::primitives::B64> {
         self.inner.nonce()
     }
 

--- a/src/network/header_response.rs
+++ b/src/network/header_response.rs
@@ -1,16 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HeaderResponse {
     #[serde(flatten)]
-    inner: alloy::rpc::types::Header,
+    inner: crate::network::header::Header,
 }
 
-impl alloy::network::HeaderResponse for HeaderResponse {
-    fn hash(&self) -> alloy::primitives::BlockHash {
-        self.inner.hash()
-    }
-
+impl alloy::consensus::BlockHeader for HeaderResponse {
     fn number(&self) -> u64 {
         self.inner.number()
     }
@@ -31,10 +27,6 @@ impl alloy::network::HeaderResponse for HeaderResponse {
         self.inner.next_block_blob_fee()
     }
 
-    fn coinbase(&self) -> alloy::primitives::Address {
-        self.inner.coinbase()
-    }
-
     fn gas_limit(&self) -> u64 {
         self.inner.gas_limit()
     }
@@ -45,5 +37,73 @@ impl alloy::network::HeaderResponse for HeaderResponse {
 
     fn difficulty(&self) -> alloy::primitives::U256 {
         self.inner.difficulty()
+    }
+
+    fn parent_hash(&self) -> alloy::primitives::B256 {
+        self.inner.parent_hash()
+    }
+
+    fn ommers_hash(&self) -> alloy::primitives::B256 {
+        self.inner.ommers_hash()
+    }
+
+    fn beneficiary(&self) -> alloy::primitives::Address {
+        self.inner.beneficiary()
+    }
+
+    fn state_root(&self) -> alloy::primitives::B256 {
+        self.inner.state_root()
+    }
+
+    fn transactions_root(&self) -> alloy::primitives::B256 {
+        self.inner.transactions_root()
+    }
+
+    fn receipts_root(&self) -> alloy::primitives::B256 {
+        self.inner.receipts_root()
+    }
+
+    fn withdrawals_root(&self) -> Option<alloy::primitives::B256> {
+        self.inner.withdrawals_root()
+    }
+
+    fn logs_bloom(&self) -> alloy::primitives::Bloom {
+        self.inner.logs_bloom()
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.inner.gas_used()
+    }
+
+    fn nonce(&self) -> Option<alloy::primitives::B64> {
+        self.inner.nonce()
+    }
+
+    fn blob_gas_used(&self) -> Option<u64> {
+        self.inner.blob_gas_used()
+    }
+
+    fn excess_blob_gas(&self) -> Option<u64> {
+        self.inner.excess_blob_gas()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<alloy::primitives::B256> {
+        self.inner.parent_beacon_block_root()
+    }
+
+    fn requests_hash(&self) -> Option<alloy::primitives::B256> {
+        self.inner.requests_hash()
+    }
+}
+
+impl alloy::network::primitives::HeaderResponse for HeaderResponse {
+    fn hash(&self) -> alloy::primitives::BlockHash {
+        self.inner.hash_slow()
+    }
+}
+
+impl AsRef<crate::network::header::Header> for HeaderResponse {
+    fn as_ref(&self) -> &crate::network::header::Header {
+        &self.inner
     }
 }

--- a/src/network/transaction_response.rs
+++ b/src/network/transaction_response.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionResponse {
     #[serde(flatten)]
-    inner: alloy::rpc::types::Transaction,
+    inner: alloy::rpc::types::transaction::Transaction<crate::network::tx_envelope::TxEnvelope>,
 }
 
 impl alloy::consensus::Transaction for TransactionResponse {
@@ -70,6 +70,14 @@ impl alloy::consensus::Transaction for TransactionResponse {
     fn kind(&self) -> alloy::primitives::TxKind {
         self.inner.kind()
     }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.inner.effective_gas_price(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.inner.is_dynamic_fee()
+    }
 }
 
 impl alloy::network::TransactionResponse for TransactionResponse {
@@ -95,5 +103,11 @@ impl alloy::network::TransactionResponse for TransactionResponse {
 
     fn transaction_index(&self) -> Option<u64> {
         self.inner.transaction_index()
+    }
+}
+
+impl AsRef<crate::network::tx_envelope::TxEnvelope> for TransactionResponse {
+    fn as_ref(&self) -> &crate::network::tx_envelope::TxEnvelope {
+        &self.inner.inner
     }
 }

--- a/src/network/tx_envelope.rs
+++ b/src/network/tx_envelope.rs
@@ -1,6 +1,6 @@
 use alloy::consensus::Signed;
 use alloy::network::eip2718::{Decodable2718, Encodable2718};
-use alloy::rlp::Header;
+use alloy::rlp::{Encodable, Header};
 use serde::{Deserialize, Serialize};
 
 use super::unsigned_tx::eip712::TxEip712;
@@ -188,7 +188,9 @@ impl Encodable2718 for TxEnvelope {
         match self {
             Self::Native(inner) => inner.encode_2718_len(),
             Self::Eip712(inner) => {
-                let payload_length = inner.tx().fields_len() + inner.signature().rlp_rs_len();
+                let payload_length = inner.tx().fields_len()
+                    + inner.signature().rlp_rs_len()
+                    + inner.signature().v().length();
                 Header {
                     list: true,
                     payload_length,

--- a/src/network/tx_envelope.rs
+++ b/src/network/tx_envelope.rs
@@ -1,13 +1,179 @@
 use alloy::consensus::Signed;
 use alloy::network::eip2718::{Decodable2718, Encodable2718};
 use alloy::rlp::Header;
+use serde::{Deserialize, Serialize};
 
 use super::unsigned_tx::eip712::TxEip712;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TxEnvelope {
     Native(alloy::consensus::TxEnvelope),
     Eip712(Signed<TxEip712>),
+}
+
+impl TxEnvelope {
+    /// Returns true if the transaction is a legacy transaction.
+    #[inline]
+    pub const fn is_legacy(&self) -> bool {
+        match self {
+            Self::Native(inner) => inner.is_legacy(),
+            Self::Eip712(_) => false,
+        }
+    }
+
+    /// Returns true if the transaction is an EIP-2930 transaction.
+    #[inline]
+    pub const fn is_eip2930(&self) -> bool {
+        match self {
+            Self::Native(inner) => inner.is_eip2930(),
+            Self::Eip712(_) => false,
+        }
+    }
+
+    /// Returns true if the transaction is an EIP-1559 transaction.
+    #[inline]
+    pub const fn is_eip1559(&self) -> bool {
+        match self {
+            Self::Native(inner) => inner.is_eip1559(),
+            Self::Eip712(_) => false,
+        }
+    }
+
+    /// Returns true if the transaction is an EIP-4844 transaction.
+    #[inline]
+    pub const fn is_eip4844(&self) -> bool {
+        match self {
+            Self::Native(inner) => inner.is_eip4844(),
+            Self::Eip712(_) => false,
+        }
+    }
+
+    /// Returns true if the transaction is an EIP-7702 transaction.
+    #[inline]
+    pub const fn is_eip7702(&self) -> bool {
+        match self {
+            Self::Native(inner) => inner.is_eip7702(),
+            Self::Eip712(_) => false,
+        }
+    }
+
+    /// Returns true if the transaction is an EIP-712 transaction.
+    #[inline]
+    pub const fn is_eip712(&self) -> bool {
+        matches!(self, Self::Eip712(_))
+    }
+
+    /// Returns true if the transaction is replay protected.
+    ///
+    /// All non-legacy transactions are replay protected, as the chain id is
+    /// included in the transaction body. Legacy transactions are considered
+    /// replay protected if the `v` value is not 27 or 28, according to the
+    /// rules of [EIP-155].
+    ///
+    /// [EIP-155]: https://eips.ethereum.org/EIPS/eip-155
+    #[inline]
+    pub const fn is_replay_protected(&self) -> bool {
+        match self {
+            Self::Native(inner) => inner.is_replay_protected(),
+            Self::Eip712(_) => true,
+        }
+    }
+
+    /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
+    pub const fn as_legacy(&self) -> Option<&Signed<alloy::consensus::TxLegacy>> {
+        match self {
+            Self::Native(inner) => inner.as_legacy(),
+            Self::Eip712(_) => None,
+        }
+    }
+
+    /// Returns the [`TxEip2930`] variant if the transaction is an EIP-2930 transaction.
+    pub const fn as_eip2930(&self) -> Option<&Signed<alloy::consensus::TxEip2930>> {
+        match self {
+            Self::Native(inner) => inner.as_eip2930(),
+            Self::Eip712(_) => None,
+        }
+    }
+
+    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    pub const fn as_eip1559(&self) -> Option<&Signed<alloy::consensus::TxEip1559>> {
+        match self {
+            Self::Native(inner) => inner.as_eip1559(),
+            Self::Eip712(_) => None,
+        }
+    }
+
+    /// Returns the [`TxEip4844`] variant if the transaction is an EIP-4844 transaction.
+    pub const fn as_eip4844(&self) -> Option<&Signed<alloy::consensus::TxEip4844Variant>> {
+        match self {
+            Self::Native(inner) => inner.as_eip4844(),
+            Self::Eip712(_) => None,
+        }
+    }
+
+    /// Returns the [`TxEip7702`] variant if the transaction is an EIP-7702 transaction.
+    pub const fn as_eip7702(&self) -> Option<&Signed<alloy::consensus::TxEip7702>> {
+        match self {
+            Self::Native(inner) => inner.as_eip7702(),
+            Self::Eip712(_) => None,
+        }
+    }
+
+    /// Returns the [`TxEip712`] variant if the transaction is an EIP-712 transaction.
+    pub const fn as_eip712(&self) -> Option<&Signed<TxEip712>> {
+        match self {
+            Self::Native(_) => None,
+            Self::Eip712(inner) => Some(inner),
+        }
+    }
+
+    /// Calculate the signing hash for the transaction.
+    pub fn signature_hash(&self) -> alloy::primitives::B256 {
+        match self {
+            Self::Native(inner) => inner.signature_hash(),
+            Self::Eip712(inner) => inner.signature_hash(),
+        }
+    }
+
+    /// Return the reference to signature.
+    pub const fn signature(&self) -> &alloy::primitives::PrimitiveSignature {
+        match self {
+            Self::Native(inner) => inner.signature(),
+            Self::Eip712(inner) => inner.signature(),
+        }
+    }
+
+    /// Return the hash of the inner Signed.
+    #[doc(alias = "transaction_hash")]
+    pub const fn tx_hash(&self) -> alloy::primitives::B256 {
+        match self {
+            Self::Native(inner) => *inner.tx_hash(),
+            Self::Eip712(inner) => *inner.hash(),
+        }
+    }
+
+    /// Return the [`TxType`] of the inner txn.
+    #[doc(alias = "transaction_type")]
+    pub const fn tx_type(&self) -> crate::network::tx_type::TxType {
+        match self {
+            Self::Native(inner) => match inner.tx_type() {
+                alloy::consensus::TxType::Legacy => crate::network::tx_type::TxType::Legacy,
+                alloy::consensus::TxType::Eip2930 => crate::network::tx_type::TxType::Eip2930,
+                alloy::consensus::TxType::Eip1559 => crate::network::tx_type::TxType::Eip1559,
+                alloy::consensus::TxType::Eip4844 => crate::network::tx_type::TxType::Eip4844,
+                alloy::consensus::TxType::Eip7702 => crate::network::tx_type::TxType::Eip7702,
+            },
+            Self::Eip712(_) => crate::network::tx_type::TxType::Eip712,
+        }
+    }
+
+    /// Return the length of the inner txn, including type byte length
+    pub fn eip2718_encoded_length(&self) -> usize {
+        match self {
+            Self::Native(inner) => inner.eip2718_encoded_length(),
+            Self::Eip712(inner) => inner.tx().encoded_length(inner.signature()),
+        }
+    }
 }
 
 impl Encodable2718 for TxEnvelope {
@@ -22,7 +188,7 @@ impl Encodable2718 for TxEnvelope {
         match self {
             Self::Native(inner) => inner.encode_2718_len(),
             Self::Eip712(inner) => {
-                let payload_length = inner.tx().fields_len() + inner.signature().rlp_vrs_len();
+                let payload_length = inner.tx().fields_len() + inner.signature().rlp_rs_len();
                 Header {
                     list: true,
                     payload_length,
@@ -52,5 +218,84 @@ impl Decodable2718 for TxEnvelope {
     fn fallback_decode(buf: &mut &[u8]) -> alloy::network::eip2718::Eip2718Result<Self> {
         let inner = alloy::consensus::TxEnvelope::fallback_decode(buf)?;
         Ok(Self::Native(inner))
+    }
+}
+
+impl AsRef<dyn alloy::consensus::Transaction> for TxEnvelope {
+    fn as_ref(&self) -> &dyn alloy::consensus::Transaction {
+        match self {
+            TxEnvelope::Native(inner) => inner,
+            TxEnvelope::Eip712(signed_inner) => signed_inner.tx(),
+        }
+    }
+}
+
+impl alloy::consensus::Transaction for TxEnvelope {
+    fn chain_id(&self) -> Option<alloy::primitives::ChainId> {
+        self.as_ref().chain_id()
+    }
+
+    fn nonce(&self) -> u64 {
+        self.as_ref().nonce()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.as_ref().gas_limit()
+    }
+
+    fn gas_price(&self) -> Option<u128> {
+        self.as_ref().gas_price()
+    }
+
+    fn max_fee_per_gas(&self) -> u128 {
+        self.as_ref().max_fee_per_gas()
+    }
+
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.as_ref().max_priority_fee_per_gas()
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.as_ref().max_fee_per_blob_gas()
+    }
+
+    fn priority_fee_or_price(&self) -> u128 {
+        self.as_ref().priority_fee_or_price()
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.as_ref().effective_gas_price(base_fee)
+    }
+
+    fn is_dynamic_fee(&self) -> bool {
+        self.as_ref().is_dynamic_fee()
+    }
+
+    fn kind(&self) -> alloy::primitives::TxKind {
+        self.as_ref().kind()
+    }
+
+    fn value(&self) -> alloy::primitives::U256 {
+        self.as_ref().value()
+    }
+
+    fn input(&self) -> &alloy::primitives::Bytes {
+        self.as_ref().input()
+    }
+
+    fn ty(&self) -> u8 {
+        self.as_ref().ty()
+    }
+
+    fn access_list(&self) -> Option<&alloy::rpc::types::AccessList> {
+        self.as_ref().access_list()
+    }
+
+    fn blob_versioned_hashes(&self) -> Option<&[alloy::primitives::B256]> {
+        self.as_ref().blob_versioned_hashes()
+    }
+
+    fn authorization_list(&self) -> Option<&[alloy::eips::eip7702::SignedAuthorization]> {
+        self.as_ref().authorization_list()
     }
 }

--- a/src/network/tx_type.rs
+++ b/src/network/tx_type.rs
@@ -14,6 +14,8 @@ pub enum TxType {
     Eip1559 = 2,
     /// EIP-4844 transaction type.
     Eip4844 = 3,
+    /// EIP-7702 transaction type.
+    Eip7702 = 4,
     /// ZKsync-specific EIP712-based transaction type.
     Eip712 = 0x71,
     // TODO: L1-based transaction type
@@ -26,6 +28,7 @@ impl TxType {
             TxType::Eip2930 => alloy::consensus::TxType::Eip2930,
             TxType::Eip1559 => alloy::consensus::TxType::Eip1559,
             TxType::Eip4844 => alloy::consensus::TxType::Eip4844,
+            TxType::Eip7702 => alloy::consensus::TxType::Eip7702,
             TxType::Eip712 => return None,
         })
     }
@@ -51,6 +54,7 @@ impl fmt::Display for TxType {
             Self::Eip2930 => write!(f, "EIP-2930"),
             Self::Eip1559 => write!(f, "EIP-1559"),
             Self::Eip4844 => write!(f, "EIP-4844"),
+            Self::Eip7702 => write!(f, "EIP-7702"),
             Self::Eip712 => write!(f, "Era EIP-712"),
         }
     }
@@ -65,6 +69,7 @@ impl TryFrom<u8> for TxType {
             1 => Self::Eip2930,
             2 => Self::Eip1559,
             3 => Self::Eip4844,
+            4 => Self::Eip7702,
             0x71 => Self::Eip712,
             _ => return Err(Eip2718Error::UnexpectedType(value)),
         })

--- a/src/network/unsigned_tx/eip712/mod.rs
+++ b/src/network/unsigned_tx/eip712/mod.rs
@@ -341,11 +341,6 @@ impl SignableTransaction<Signature> for TxEip712 {
     }
 
     fn into_signed(self, signature: Signature) -> Signed<Self> {
-        // Drop any v chain id value to ensure the signature format is correct at the time of
-        // combination for an EIP-1559 transaction. V should indicate the y-parity of the
-        // signature.
-        let signature = signature.with_parity(true);
-
         let mut buf = [0u8; 64];
         buf[..32].copy_from_slice(self.signature_hash().as_slice());
         buf[32..].copy_from_slice(keccak256(signature.as_bytes()).as_slice());

--- a/src/network/unsigned_tx/eip712/mod.rs
+++ b/src/network/unsigned_tx/eip712/mod.rs
@@ -507,7 +507,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eip712_tx1() {
+    fn test_eip712_tx() {
         let eip712_meta = Eip712Meta {
             gas_per_pubdata: U256::from(4),
             factory_deps: vec![vec![2; 32].into()],

--- a/src/network/unsigned_tx/eip712/mod.rs
+++ b/src/network/unsigned_tx/eip712/mod.rs
@@ -222,6 +222,7 @@ impl TxEip712 {
 
     /// Gets the length of the encoded header.
     pub(crate) fn encoded_length(&self, signature: &Signature) -> usize {
+        let payload_length = self.fields_len() + signature.rlp_rs_len() + signature.v().length();
         alloy::rlp::length_of_length(payload_length) + payload_length
     }
 

--- a/src/network/unsigned_tx/eip712/mod.rs
+++ b/src/network/unsigned_tx/eip712/mod.rs
@@ -222,10 +222,7 @@ impl TxEip712 {
 
     /// Gets the length of the encoded header.
     pub(crate) fn encoded_length(&self, signature: &Signature) -> usize {
-        let payload_length = self.fields_len() + signature.rlp_rs_len();
-        let x = alloy::rlp::length_of_length(payload_length) + payload_length;
-        println!("!!! LEN {x}");
-        x
+        alloy::rlp::length_of_length(payload_length) + payload_length
     }
 
     /// Get transaction type

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -219,9 +219,9 @@ where
 }
 
 impl RecommendedFillers for Zksync {
-    type RecomendedFillers = JoinFill<Eip712FeeFiller, JoinFill<NonceFiller, ChainIdFiller>>;
+    type RecommendedFillers = JoinFill<Eip712FeeFiller, JoinFill<NonceFiller, ChainIdFiller>>;
 
-    fn recommended_fillers() -> Self::RecomendedFillers {
+    fn recommended_fillers() -> Self::RecommendedFillers {
         JoinFill::new(
             Eip712FeeFiller::default(),
             JoinFill::new(NonceFiller::default(), ChainIdFiller::default()),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -4,7 +4,7 @@ use alloy::primitives::Address;
 
 use crate::network::{tx_envelope::TxEnvelope, unsigned_tx::TypedTransaction, Zksync};
 
-use alloy::signers::Signature;
+use alloy::primitives::PrimitiveSignature as Signature;
 use std::{collections::BTreeMap, sync::Arc};
 
 /// A wallet capable of signing any transaction for the Ethereum network.


### PR DESCRIPTION
* Support alloy v0.6.0
* Wrap `alloy::consensus::TxEnvelope` properly into newtype `crate::TxEnvelope` so it can be used with `AsRef<Self::____>` traits that are now required by `alloy::network::Network`.