### PR TITLE
fix: use create2 input when salt is specified in TransactionRequest

### DIFF
--- a/src/contracts/l2/contract_deployer.rs
+++ b/src/contracts/l2/contract_deployer.rs
@@ -11,6 +11,8 @@ pub const CONTRACT_DEPLOYER_ADDRESS: Address = Address::new([
 alloy::sol! {
     function create(bytes32 salt, bytes32 bytecodeHash, bytes memory constructorInput);
 
+    function create2(bytes32 salt, bytes32 bytecodeHash, bytes memory constructorInput);
+
     event ContractDeployed(
         address indexed deployerAddress,
         bytes32 indexed bytecodeHash,
@@ -18,13 +20,25 @@ alloy::sol! {
     );
 }
 
-pub(crate) fn encode_create_calldata(
-    salt: Option<B256>,
+pub(crate) fn encode_create_calldata(bytecode_hash: B256, constructor_input: Bytes) -> Bytes {
+    // The salt parameter is required as per signature but is not used during create
+    // See: https://github.com/matter-labs/era-contracts/blob/main/system-contracts/contracts/interfaces/IContractDeployer.sol#L65
+    let call = createCall {
+        salt: Default::default(),
+        bytecodeHash: bytecode_hash,
+        constructorInput: constructor_input,
+    };
+
+    call.abi_encode().into()
+}
+
+pub(crate) fn encode_create2_calldata(
+    salt: B256,
     bytecode_hash: B256,
     constructor_input: Bytes,
 ) -> Bytes {
     let call = createCall {
-        salt: salt.unwrap_or_default(),
+        salt,
         bytecodeHash: bytecode_hash,
         constructorInput: constructor_input,
     };

--- a/src/network/transaction_request/mod.rs
+++ b/src/network/transaction_request/mod.rs
@@ -104,14 +104,13 @@ impl TransactionRequest {
                 salt,
                 bytecode_hash.into(),
                 constructor_data.into(),
-            )
-            .into(),
+            ),
             None => crate::contracts::l2::contract_deployer::encode_create_calldata(
                 bytecode_hash.into(),
                 constructor_data.into(),
-            )
-            .into(),
-        };
+            ),
+        }
+        .into();
         self.eip_712_meta
             .get_or_insert_with(Eip712Meta::default)
             .factory_deps = factory_deps.into_iter().map(Into::into).collect();

--- a/src/network/transaction_request/mod.rs
+++ b/src/network/transaction_request/mod.rs
@@ -99,12 +99,19 @@ impl TransactionRequest {
         let bytecode_hash = hash_bytecode(&code)?;
         factory_deps.push(code);
         self.base.to = Some(CONTRACT_DEPLOYER_ADDRESS.into());
-        self.base.input = crate::contracts::l2::contract_deployer::encode_create_calldata(
-            salt,
-            bytecode_hash.into(),
-            constructor_data.into(),
-        )
-        .into();
+        self.base.input = match salt {
+            Some(salt) => crate::contracts::l2::contract_deployer::encode_create2_calldata(
+                salt,
+                bytecode_hash.into(),
+                constructor_data.into(),
+            )
+            .into(),
+            None => crate::contracts::l2::contract_deployer::encode_create_calldata(
+                bytecode_hash.into(),
+                constructor_data.into(),
+            )
+            .into(),
+        };
         self.eip_712_meta
             .get_or_insert_with(Eip712Meta::default)
             .factory_deps = factory_deps.into_iter().map(Into::into).collect();


### PR DESCRIPTION
In ZKsync era `create` and `create2` functions on `IContractDeployer` have same signature but the `salt` is ignored in favor of nonce on `create2` as per [docs](https://github.com/matter-labs/era-contracts/blob/main/system-contracts/contracts/interfaces/IContractDeployer.sol#L65).

Hence the correct behavior is to call `create2` when a salt must be specified.