### PR TITLE
fix: do not compute hash for blocks

### DIFF
--- a/src/network/header_response.rs
+++ b/src/network/header_response.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct HeaderResponse {
+    hash: alloy::primitives::BlockHash,
     #[serde(flatten)]
     inner: crate::network::header::Header,
 }
@@ -98,7 +99,7 @@ impl alloy::consensus::BlockHeader for HeaderResponse {
 
 impl alloy::network::primitives::HeaderResponse for HeaderResponse {
     fn hash(&self) -> alloy::primitives::BlockHash {
-        self.inner.hash_slow()
+        self.hash
     }
 }
 


### PR DESCRIPTION
Computing block hash does make sense in ZKsync. We should rely on structure field instead.