### PR TITLE
chore: patches alloy-chains to use version 0.1.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,12 +64,10 @@ dependencies = [
 [[package]]
 name = "alloy-chains"
 version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab9d1367c6ffb90c93fb4a9a4989530aa85112438c6f73a734067255d348469"
+source = "git+https://github.com/alloy-rs/chains?tag=v0.1.57#e4d7a1978795faa86e1f832b48e7ba9578002ec5"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "serde",
  "strum",
 ]
 
@@ -676,7 +674,6 @@ name = "alloy-zksync"
 version = "0.9.0"
 dependencies = [
  "alloy",
- "alloy-chains",
  "alloy-consensus-any",
  "anyhow",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,12 +63,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.53"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da226340862e036ab26336dc99ca85311c6b662267c1440e1733890fd688802c"
+checksum = "4ab9d1367c6ffb90c93fb4a9a4989530aa85112438c6f73a734067255d348469"
 dependencies = [
  "alloy-primitives",
  "num_enum",
+ "serde",
  "strum",
 ]
 
@@ -675,6 +676,7 @@ name = "alloy-zksync"
 version = "0.9.0"
 dependencies = [
  "alloy",
+ "alloy-chains",
  "alloy-consensus-any",
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ alloy = { version = "0.9.2", features = [
   "sol-types",
 ] } # TODO: Set features granularly?
 alloy-consensus-any = { version = "0.9.2" }
+alloy-chains = "0.1.57"
 async-trait = "0.1.80"
 chrono = { version = "0.4.38", features = ["serde"] }
 futures-utils-wasm = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ alloy = { version = "0.9.2", features = [
   "sol-types",
 ] } # TODO: Set features granularly?
 alloy-consensus-any = { version = "0.9.2" }
-alloy-chains = "0.1.57"
 async-trait = "0.1.80"
 chrono = { version = "0.4.38", features = ["serde"] }
 futures-utils-wasm = "0.1.0"
@@ -33,3 +32,7 @@ hex = "0.4.3"
 assert_matches = "1.5.0"
 serde_json = "1.0.1"
 jsonrpsee = { version = "0.24.7", features = ["server"] }
+
+[patch.crates-io]
+alloy-chains = { git = "https://github.com/alloy-rs/chains", tag = "v0.1.57" }
+


### PR DESCRIPTION
## Description 

Alloy version = "0.9.2" ships with alloy-chains 0.1.53 which was causing the following error when attempting to use in https://github.com/matter-labs/anvil-zksync/pull/559. You can see the error output below. 

Alloy version "0.10.0" is not [available on crates.io](https://crates.io/crates/alloy) yet so temporarily patching alloy-chains to make use of "0.1.57". 

New release / publish of `alloy-zksync` required for https://github.com/matter-labs/anvil-zksync/pull/559

Error output from `0.1.53`:

```
error[E0080]: evaluation of constant value failed
    --> /Users/dustinbrickwood/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hex-literal-0.4.1/src/lib.rs:17:24
     |
17   |             0..=127 => panic!("Encountered invalid ASCII character"),
     |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Encountered invalid ASCII character', /Users/dustinbrickwood/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hex-literal-0.4.1/src/lib.rs:17:24
     |
note: inside `hex_literal::next_hex_char`
    --> /Users/dustinbrickwood/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hex-literal-0.4.1/src/lib.rs:17:24
     |
17   |             0..=127 => panic!("Encountered invalid ASCII character"),
     |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `hex_literal::next_byte`
    --> /Users/dustinbrickwood/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hex-literal-0.4.1/src/lib.rs:30:30
     |
30   |     let (half2, pos) = match next_hex_char(string, pos) {
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `alloy_primitives::hex_literal::len`
    --> /Users/dustinbrickwood/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hex-literal-0.4.1/src/lib.rs:46:40
     |
46   |         while let Some((_, new_pos)) = next_byte(strings[i], pos) {
     |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `NamedChain::wrapped_native_token::LEN`
    --> /Users/dustinbrickwood/.cargo/registry/src/index.crates.io-6f17d22bba15001f/alloy-chains-0.1.53/src/named.rs:1628:25
     |
1628 |             Treasure => address!("0x263d8f36bb8d0d9526255e205868c26690b04b88"),
     |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `address` (in Nightly builds, run with -Z macro-backtrace for more info)

note: erroneous constant encountered
    --> /Users/dustinbrickwood/.cargo/registry/src/index.crates.io-6f17d22bba15001f/alloy-chains-0.1.53/src/named.rs:1628:25
     |
1628 |             Treasure => address!("0x263d8f36bb8d0d9526255e205868c26690b04b88"),
     |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this note originates in the macro `$crate::hex` which comes from the expansion of the macro `address` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0080`.
error: could not compile `alloy-chains` (lib) due to 1 previous error
```