### PR TITLE
feat: spawn/kill anvil-zksync with PGID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "k256",
+ "libc",
  "rand",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ alloy = { version = "0.9.2", default-features = false, features = [
 async-trait = "0.1.80"
 chrono = { version = "0.4.38", features = ["serde"] }
 k256 = "0.13.3"
+libc = "0.2.169"
 rand = "0.8.5"
 reqwest = "0.12.8"
 serde = "1.0.203"


### PR DESCRIPTION
Encountered an issue with the WIP version of `anvil-zksync` that now spawns an L1 `anvil` subprocess. Killing `anvil-zksync` by PID turns `anvil` subprocess a zombie.

There isn't much we can do on `anvil-zksync` side as std doesn't bother with SIGTERM and sends SIGKILL right off the bat. Thus we can't register a proper handler.

Note: this is UNIX-specific, no idea what proper solution for Windows would look like