### PR TITLE
feat: adding support for 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "crc",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -213,7 +213,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
@@ -239,7 +239,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -274,7 +274,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "ruint",
  "rustc-hash",
  "serde",
@@ -311,7 +311,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "url",
@@ -403,7 +403,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -428,7 +428,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -443,8 +443,8 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand",
- "thiserror 2.0.10",
+ "rand 0.8.5",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -582,11 +582,11 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "k256",
- "rand",
+ "rand 0.9.0",
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "url",
@@ -724,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -734,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -776,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1045,7 +1045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1187,7 +1187,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1252,7 +1252,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1263,7 +1263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1424,7 +1424,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1446,7 +1458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1871,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
+checksum = "834af00800e962dee8f7bfc0f60601de215e73e78e5497d733a2919da837d3c8"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-server",
@@ -1895,7 +1907,7 @@ dependencies = [
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2059,7 +2071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2277,7 +2289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "ucd-trie",
 ]
 
@@ -2335,7 +2347,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2400,8 +2412,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2437,9 +2449,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -2449,7 +2472,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -2458,7 +2491,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -2467,7 +2510,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2547,7 +2590,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -2588,7 +2631,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "ruint-macro",
  "serde",
@@ -2812,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -2898,7 +2941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2941,7 +2984,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
 ]
 
@@ -3090,7 +3133,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -3107,11 +3150,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.10",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -3127,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3450,6 +3493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,6 +3723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3722,7 +3783,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -3730,6 +3800,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,19 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,9 +25,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcc41e8a11a4975b18ec6afba2cc48d591fa63336a4c526dacb50479a8d6b35"
+checksum = "e5295219c9bc87cfa2497131423921e8ea136ee7e2ab338967078995168431d5"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -70,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4138dc275554afa6f18c4217262ac9388790b2fc393c2dfe03c51d357abf013"
+checksum = "ce20c85f6b24a5da40b2350a748e348417f0465dedbb523a4d149143bc4a41ce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -87,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa04e1882c31288ce1028fdf31b6ea94cfa9eafa2e497f903ded631c8c6a42c"
+checksum = "8e23af02ccded0031ef2b70df4fe9965b1c742c5d5384c8c767ae0311f7e62b9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -101,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f21886c1fea0626f755a49b2ac653b396fb345233f6170db2da3d0ada31560c"
+checksum = "71c7a59f261333db00fa10a3de9480f31121bb919ad38487040d7833d5982203"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -150,6 +137,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip2124"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "thiserror 2.0.10",
+]
+
+[[package]]
 name = "alloy-eip2930"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,15 +173,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dd5869ed09e399003e0e0ec6903d981b2a92e74c5d37e6b40890bad2517526"
+checksum = "7149e011edbd588f6df6564b369c75f6b538d76db14053d95e0b43b2d92e4266"
 dependencies = [
+ "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "auto_impl",
  "c-kzg",
  "derive_more",
  "once_cell",
@@ -204,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2008bedb8159a255b46b7c8614516eda06679ea82f620913679afbd8031fea72"
+checksum = "c0c5c9651fd20a2fd4a57606b6a570d1c17ab86e686b962b2f1ecac68b51e020"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -218,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556f01fe41d0677495df10a648ddcf7ce118b0e8aa9642a0e2b6dd1fb7259de"
+checksum = "b02ed56783fb2c086a4ac8961175dd6d3ad163e6cf6125f0b83f7de03379b607"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -243,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31c3c6b71340a1d076831823f09cb6e02de01de5c6630a9631bdb36f947ff80"
+checksum = "a0624cfa9311aa8283cd3bf5eed883d0d1e823e2a4d57b30e1b49af4b3678a6b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -283,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22c4441b3ebe2d77fa9cf629ba68c3f713eb91779cff84275393db97eddd82"
+checksum = "07c68df5354225da542efeb6d9388b65773b3304309b437416146e9d1e2bc1bd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -308,7 +309,6 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "reqwest",
- "schnellru",
  "serde",
  "serde_json",
  "thiserror 2.0.10",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06a292b37e182e514903ede6e623b9de96420e8109ce300da288a96d88b7e4b"
+checksum = "0371aae9b44a35e374c94c7e1df5cbccf0f52b2ef7c782291ed56e86d88ec106"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9383845dd924939e7ab0298bbfe231505e20928907d7905aa3bf112287305e06"
+checksum = "1428d64569961b00373c503a3de306656e94ef1f2a474e93fd41a6daae0d6ac7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca445cef0eb6c2cf51cfb4e214fbf1ebd00893ae2e6f3b944c8101b07990f988"
+checksum = "66e119337400d8b0348e1576ab37ffa56d1a04cbc977a84d4fa0a527d7cb0c21"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0938bc615c02421bd86c1733ca7205cc3d99a122d9f9bff05726bd604b76a5c2"
+checksum = "8a4a43d8b1344e3ef115ed7a2cee934876e4a64d2b9d9bee8738f9806900757e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
+checksum = "86aa42c36e3c0db5bd9a7314e98aa261a61d5e3d6a0bd7e51fb8b0a3d6438481"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfa395ad5cc952c82358d31e4c68b27bf4a89a5456d9b27e226e77dac50e4ff"
+checksum = "c613222abd016e03ba548f41db938a2c99108b59c0c66ca105eab1b7a2e6b40a"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc63ce9eda1283fcbaca66ba4a414b841c0e3edbeef9c86a71242fc9e84ccc"
+checksum = "39163b956c81e8fd9605194d6b5b92dd93b0e0252810e69f9a4cebe3a8614f46"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -522,13 +522,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17722a198f33bbd25337660787aea8b8f57814febb7c746bc30407bdfc39448"
+checksum = "40e2f34fcd849676c8fe274a6e72f0664dfede7ce06d12daa728d2e72f1b4393"
 dependencies = [
  "alloy-json-rpc",
  "base64",
- "futures-util",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -542,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1509599021330a31c4a6816b655e34bf67acb1cc03c564e09fd8754ff6c5de"
+checksum = "6e291c97c3c0ebb5d03c34e3a55c0f7c5bfa307536a2efaaa6fae4b3a4d09851"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1013,6 +1012,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,12 +1468,6 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -2016,9 +2024,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -2713,17 +2721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "schnellru"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
-dependencies = [
- "ahash",
- "cfg-if",
- "hashbrown 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "alloy-zksync"
-version = "0.9.1"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT OR Apache-2.0"
 description = "ZKsync network implementation for alloy"
 
 [dependencies]
-alloy = { version = "0.9.2", default-features = false, features = [
+alloy = { version = "0.11.0", default-features = false, features = [
   "rlp",
-  "serde", # TODO: Make optional along with other `serde` dependencies
+  "serde",        # TODO: Make optional along with other `serde` dependencies
   "rpc-types",
   "signer-local",
   "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-zksync"
-version = "0.9.1"
+version = "0.11.0"
 edition = "2021"
 authors = ["Igor Aleksanov <popzxc@yandex.ru>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ alloy = { version = "0.11.0", default-features = false, features = [
   "reqwest",
   "contract",
 ] }
-async-trait = "0.1.80"
+async-trait = "0.1.86"
 chrono = { version = "0.4.38", features = ["serde"] }
 k256 = "0.13.3"
-rand = "0.8.5"
+rand = "0.9.0"
 reqwest = "0.12.8"
 serde = "1.0.203"
-thiserror = "2.0.10"
+thiserror = "2.0.11"
 tracing = "0.1.40"
 url = "2.5.2"
 
@@ -30,5 +30,5 @@ tokio = { version = "1.43.0", features = ["full"] }
 anyhow = "1"
 hex = "0.4.3"
 assert_matches = "1.5.0"
-serde_json = "1.0.1"
-jsonrpsee = { version = "0.24.7", features = ["server"] }
+serde_json = "1.0.138"
+jsonrpsee = { version = "0.24.8", features = ["server"] }

--- a/examples/deposit_erc20.rs
+++ b/examples/deposit_erc20.rs
@@ -37,10 +37,7 @@ async fn main() -> Result<()> {
             .expect("should parse private key");
     let wallet = EthereumWallet::from(signer.clone());
 
-    let l1_provider = ProviderBuilder::new()
-        .with_recommended_fillers()
-        .wallet(wallet)
-        .on_http(l1_rpc_url);
+    let l1_provider = ProviderBuilder::new().wallet(wallet).on_http(l1_rpc_url);
 
     let l1_gas_price = l1_provider.get_gas_price().await?;
     // Deploy a test ERC20 token to be used for the deposit.
@@ -51,10 +48,7 @@ async fn main() -> Result<()> {
     println!("L1 ERC20 token address: {}", erc20_token_address);
 
     let zksync_wallet: ZksyncWallet = ZksyncWallet::from(signer.clone());
-    let zksync_provider = zksync_provider()
-        .with_recommended_fillers()
-        .wallet(zksync_wallet)
-        .on_http(l2_rpc_url);
+    let zksync_provider = zksync_provider().wallet(zksync_wallet).on_http(l2_rpc_url);
 
     // use another test rich wallet as a receiver
     // https://github.com/matter-labs/local-setup/blob/main/rich-wallets.json

--- a/examples/deposit_eth.rs
+++ b/examples/deposit_eth.rs
@@ -28,13 +28,11 @@ async fn main() -> Result<()> {
     let wallet = EthereumWallet::from(signer.clone());
 
     let l1_provider = ProviderBuilder::new()
-        .with_recommended_fillers()
         .wallet(wallet)
         .on_http(l1_rpc_url);
 
     let zksync_wallet: ZksyncWallet = ZksyncWallet::from(signer.clone());
     let zksync_provider = zksync_provider()
-        .with_recommended_fillers()
         .wallet(zksync_wallet)
         .on_http(l2_rpc_url);
 

--- a/examples/deposit_eth.rs
+++ b/examples/deposit_eth.rs
@@ -27,14 +27,10 @@ async fn main() -> Result<()> {
             .expect("should parse private key");
     let wallet = EthereumWallet::from(signer.clone());
 
-    let l1_provider = ProviderBuilder::new()
-        .wallet(wallet)
-        .on_http(l1_rpc_url);
+    let l1_provider = ProviderBuilder::new().wallet(wallet).on_http(l1_rpc_url);
 
     let zksync_wallet: ZksyncWallet = ZksyncWallet::from(signer.clone());
-    let zksync_provider = zksync_provider()
-        .wallet(zksync_wallet)
-        .on_http(l2_rpc_url);
+    let zksync_provider = zksync_provider().wallet(zksync_wallet).on_http(l2_rpc_url);
 
     // use another test rich wallet as a receiver
     // https://github.com/matter-labs/local-setup/blob/main/rich-wallets.json

--- a/src/contracts/common/erc20.rs
+++ b/src/contracts/common/erc20.rs
@@ -35,12 +35,11 @@ alloy::sol! {
 ///
 /// A `Result` containing the encoded token data as `Bytes` or an `Error`.
 /// ```
-pub(crate) async fn encode_token_data_for_bridge<T, P, N>(
-    erc20_contract: &ERC20Instance<T, P, N>,
+pub(crate) async fn encode_token_data_for_bridge<P, N>(
+    erc20_contract: &ERC20Instance<P, N>,
 ) -> Result<Bytes, Error>
 where
-    T: Transport + Clone,
-    P: alloy::providers::Provider<T, N>,
+    P: alloy::providers::Provider<N>,
     N: Network,
 {
     let erc20_name = erc20_contract.name().call().await?._0;

--- a/src/contracts/common/erc20.rs
+++ b/src/contracts/common/erc20.rs
@@ -1,11 +1,10 @@
 //! ZKsync-specific utilities related to ERC20 contracts.
 
+use alloy::network::Ethereum;
 use alloy::{
     contract::Error,
     dyn_abi::DynSolValue,
-    network::Network,
     primitives::{Bytes, U256},
-    transports::Transport,
 };
 use ERC20::ERC20Instance;
 
@@ -35,12 +34,11 @@ alloy::sol! {
 ///
 /// A `Result` containing the encoded token data as `Bytes` or an `Error`.
 /// ```
-pub(crate) async fn encode_token_data_for_bridge<P, N>(
-    erc20_contract: &ERC20Instance<P, N>,
+pub(crate) async fn encode_token_data_for_bridge<P>(
+    erc20_contract: &ERC20Instance<(), P>,
 ) -> Result<Bytes, Error>
 where
-    P: alloy::providers::Provider<N>,
-    N: Network,
+    P: alloy::providers::Provider<Ethereum>,
 {
     let erc20_name = erc20_contract.name().call().await?._0;
     let erc20_symbol = erc20_contract.symbol().call().await?._0;

--- a/src/network/receipt_envelope.rs
+++ b/src/network/receipt_envelope.rs
@@ -1,9 +1,9 @@
-use core::fmt;
-
 use alloy::consensus::{TxReceipt, TxType};
-use alloy::network::eip2718::{Decodable2718, Eip2718Error, Encodable2718};
+use alloy::network::eip2718::{Decodable2718, Eip2718Error, Encodable2718, Typed2718};
 use alloy::network::AnyReceiptEnvelope;
 use alloy::primitives::Log;
+use core::convert::TryInto;
+use core::fmt;
 use serde::{Deserialize, Serialize};
 
 /// Receipt envelope is a wrapper around the receipt data.
@@ -58,6 +58,15 @@ where
         match self {
             ReceiptEnvelope::Native(re) => re.logs(),
             ReceiptEnvelope::Eip712(re) => re.logs(),
+        }
+    }
+}
+
+impl Typed2718 for ReceiptEnvelope {
+    fn ty(&self) -> u8 {
+        match self {
+            ReceiptEnvelope::Native(re) => re.ty(),
+            ReceiptEnvelope::Eip712(re) => re.ty(),
         }
     }
 }

--- a/src/network/receipt_response.rs
+++ b/src/network/receipt_response.rs
@@ -107,11 +107,6 @@ impl<T: TxReceipt<Log = Log>> alloy::network::ReceiptResponse for ReceiptRespons
         self.inner.to()
     }
 
-    /// EIP-7702 Authorization list.
-    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
-        self.inner.authorization_list()
-    }
-
     /// Returns the cumulative gas used at this receipt.
     fn cumulative_gas_used(&self) -> u64 {
         self.inner.cumulative_gas_used()

--- a/src/network/receipt_response.rs
+++ b/src/network/receipt_response.rs
@@ -6,7 +6,6 @@ use alloy::rpc::types::{Log, TransactionReceipt};
 
 use super::receipt_envelope::ReceiptEnvelope;
 use crate::types::*;
-use alloy::eips::eip7702::SignedAuthorization;
 
 /// Transaction receipt type that includes L2 specific fields.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/network/receipt_response.rs
+++ b/src/network/receipt_response.rs
@@ -43,6 +43,11 @@ impl ReceiptResponse {
     pub fn l2_to_l1_logs(&self) -> &[L2ToL1Log] {
         &self.l2_to_l1_logs
     }
+
+    /// Returns the authorization list for the transaction.
+    pub fn authorization_list(&self) -> Option<&Vec<Address>> {
+        None
+    }
 }
 
 impl<T: TxReceipt<Log = Log>> alloy::network::ReceiptResponse for ReceiptResponse<T> {

--- a/src/node_bindings/anvil_zksync.rs
+++ b/src/node_bindings/anvil_zksync.rs
@@ -458,8 +458,7 @@ mod tests {
         let chain_id = 92;
         let anvil_zksync = AnvilZKsync::new().chain_id(chain_id).spawn();
         let rpc_url = anvil_zksync.endpoint_url();
-        let provider = ProviderBuilder::new()
-            .on_http(rpc_url);
+        let provider = ProviderBuilder::new().on_http(rpc_url);
 
         let returned_chain_id = provider.get_chain_id().await.unwrap();
 
@@ -473,8 +472,7 @@ mod tests {
     async fn fork_initializes_correct_chain() {
         let anvil_zksync = AnvilZKsync::new().fork("mainnet").spawn();
         let rpc_url = anvil_zksync.endpoint_url();
-        let provider = ProviderBuilder::new()
-            .on_http(rpc_url);
+        let provider = ProviderBuilder::new().on_http(rpc_url);
 
         let chain_id = provider.get_chain_id().await.unwrap();
 
@@ -493,8 +491,7 @@ mod tests {
             .spawn();
 
         let rpc_url = anvil_zksync.endpoint_url();
-        let provider = ProviderBuilder::new()
-            .on_http(rpc_url);
+        let provider = ProviderBuilder::new().on_http(rpc_url);
 
         // Query the latest block number to verify the fork block number.
         let block_number = provider.get_block_number().await.unwrap();

--- a/src/node_bindings/anvil_zksync.rs
+++ b/src/node_bindings/anvil_zksync.rs
@@ -459,7 +459,6 @@ mod tests {
         let anvil_zksync = AnvilZKsync::new().chain_id(chain_id).spawn();
         let rpc_url = anvil_zksync.endpoint_url();
         let provider = ProviderBuilder::new()
-            .with_recommended_fillers()
             .on_http(rpc_url);
 
         let returned_chain_id = provider.get_chain_id().await.unwrap();
@@ -475,7 +474,6 @@ mod tests {
         let anvil_zksync = AnvilZKsync::new().fork("mainnet").spawn();
         let rpc_url = anvil_zksync.endpoint_url();
         let provider = ProviderBuilder::new()
-            .with_recommended_fillers()
             .on_http(rpc_url);
 
         let chain_id = provider.get_chain_id().await.unwrap();
@@ -496,7 +494,6 @@ mod tests {
 
         let rpc_url = anvil_zksync.endpoint_url();
         let provider = ProviderBuilder::new()
-            .with_recommended_fillers()
             .on_http(rpc_url);
 
         // Query the latest block number to verify the fork block number.

--- a/src/node_bindings/anvil_zksync.rs
+++ b/src/node_bindings/anvil_zksync.rs
@@ -177,7 +177,7 @@ impl AnvilZKsync {
     pub fn new() -> Self {
         let mut self_ = Self::default();
         // Assign a random port so that we can run multiple instances.
-        let port = rand::thread_rng().gen_range(8000..16000);
+        let port = rand::rng().random_range(8000..16000);
         self_.port = Some(port);
         self_
     }

--- a/src/provider/deposit.rs
+++ b/src/provider/deposit.rs
@@ -23,9 +23,8 @@ use alloy::{
     primitives::{Address, Bytes, U256},
     providers::{utils::Eip1559Estimation, WalletProvider},
     rpc::types::eth::TransactionRequest as L1TransactionRequest,
-    transports::Transport,
 };
-use std::{marker::PhantomData, str::FromStr};
+use std::str::FromStr;
 
 pub const REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT: u64 = 800;
 
@@ -248,7 +247,7 @@ where
 
     async fn get_bridge_l2_tx_fee_params<P>(
         &self,
-        bridge_hub_contract: &Bridgehub::BridgehubInstance<P, Ethereum>,
+        bridge_hub_contract: &Bridgehub::BridgehubInstance<(), &P>,
         l1_to_l2_tx: TransactionRequest,
         l2_chain_id: U256,
         fee_params: &FeeParams,

--- a/src/provider/deposit.rs
+++ b/src/provider/deposit.rs
@@ -134,23 +134,20 @@ pub fn scale_l1_gas_limit(l1_gas_limit: u64) -> u64 {
 }
 
 /// Type that handles deposit logic for various scenarios: deposit ETH, ERC20 etc.
-pub struct DepositExecutor<'a, T, P1, P2>
+pub struct DepositExecutor<'a, P1, P2>
 where
-    P1: alloy::providers::Provider<T, Ethereum>,
-    P2: ZksyncProvider<T> + WalletProvider<Zksync> + ?Sized,
-    T: Transport + Clone,
+    P1: alloy::providers::Provider<Ethereum>,
+    P2: ZksyncProvider + WalletProvider<Zksync> + ?Sized,
 {
     l1_provider: &'a P1,
     l2_provider: &'a P2,
     request: &'a DepositRequest,
-    _transport_phantom: PhantomData<T>,
 }
 
-impl<'a, T, P1, P2> DepositExecutor<'a, T, P1, P2>
+impl<'a, P1, P2> DepositExecutor<'a, P1, P2>
 where
-    P1: alloy::providers::Provider<T, Ethereum>,
-    P2: ZksyncProvider<T> + WalletProvider<Zksync> + ?Sized,
-    T: Transport + Clone,
+    P1: alloy::providers::Provider<Ethereum>,
+    P2: ZksyncProvider + WalletProvider<Zksync> + ?Sized,
 {
     /// Prepares an executor for a particular deposit request.
     pub fn new(l1_provider: &'a P1, l2_provider: &'a P2, request: &'a DepositRequest) -> Self {
@@ -158,7 +155,6 @@ where
             l1_provider,
             l2_provider,
             request,
-            _transport_phantom: PhantomData,
         }
     }
 
@@ -250,16 +246,15 @@ where
         Ok(l1_gas_limit)
     }
 
-    async fn get_bridge_l2_tx_fee_params<Tr, P>(
+    async fn get_bridge_l2_tx_fee_params<P>(
         &self,
-        bridge_hub_contract: &Bridgehub::BridgehubInstance<Tr, P, Ethereum>,
+        bridge_hub_contract: &Bridgehub::BridgehubInstance<P, Ethereum>,
         l1_to_l2_tx: TransactionRequest,
         l2_chain_id: U256,
         fee_params: &FeeParams,
     ) -> Result<BridgeL2TxFeeParams, L1CommunicationError>
     where
-        Tr: Transport + Clone,
-        P: alloy::providers::Provider<Tr, Ethereum>,
+        P: alloy::providers::Provider<Ethereum>,
     {
         let gas_limit = self
             .l2_provider
@@ -454,7 +449,7 @@ where
     async fn submit(
         &self,
         tx_request: &L1TransactionRequest,
-    ) -> Result<L1TransactionReceipt<T>, L1CommunicationError> {
+    ) -> Result<L1TransactionReceipt, L1CommunicationError> {
         let l1_gas_limit = self.get_l1_tx_gas_limit(tx_request).await?;
         let l1_tx_request = tx_request.clone().with_gas_limit(l1_gas_limit);
         let l1_tx_receipt = self
@@ -491,7 +486,7 @@ where
     /// ## Returns
     ///
     /// L1TransactionReceipt of the deposit transaction.
-    pub async fn execute(&self) -> Result<L1TransactionReceipt<T>, L1CommunicationError> {
+    pub async fn execute(&self) -> Result<L1TransactionReceipt, L1CommunicationError> {
         let l2_chain_id = U256::from(self.l2_provider.get_chain_id().await.map_err(|_| {
             L1CommunicationError::Custom("Error occurred while fetching L2 chain id.")
         })?);

--- a/src/provider/fillers/mod.rs
+++ b/src/provider/fillers/mod.rs
@@ -40,14 +40,13 @@ impl TxFiller<Zksync> for Eip712FeeFiller {
 
     fn fill_sync(&self, _tx: &mut SendableTx<Zksync>) {}
 
-    async fn prepare<P, T>(
+    async fn prepare<P>(
         &self,
         provider: &P,
         tx: &TransactionRequest,
     ) -> TransportResult<Self::Fillable>
     where
-        P: Provider<T, Zksync>,
-        T: Transport + Clone,
+        P: Provider<Zksync>,
     {
         let fee = provider.estimate_fee(tx.clone()).await?;
         Ok(fee)

--- a/src/provider/fillers/mod.rs
+++ b/src/provider/fillers/mod.rs
@@ -7,7 +7,7 @@ use alloy::{
         fillers::{FillerControlFlow, TxFiller},
         Provider, SendableTx,
     },
-    transports::{Transport, TransportResult},
+    transports::TransportResult,
 };
 
 use crate::network::{transaction_request::TransactionRequest, Zksync};

--- a/src/provider/l1_transaction_receipt.rs
+++ b/src/provider/l1_transaction_receipt.rs
@@ -3,7 +3,6 @@ use crate::{contracts::l1::bridge_hub::Bridgehub::NewPriorityRequest, network::Z
 use alloy::{
     providers::{PendingTransactionBuilder, RootProvider},
     rpc::types::eth::TransactionReceipt,
-    transports::Transport,
 };
 
 /// A wrapper struct to hold L1 transaction receipt and L2 provider

--- a/src/provider/l1_transaction_receipt.rs
+++ b/src/provider/l1_transaction_receipt.rs
@@ -8,19 +8,16 @@ use alloy::{
 
 /// A wrapper struct to hold L1 transaction receipt and L2 provider
 /// which is used by the associated functions.
-pub struct L1TransactionReceipt<T> {
+pub struct L1TransactionReceipt {
     /// Ethereum transaction receipt.
     inner: TransactionReceipt,
     /// A reference to the L2 provider.
-    l2_provider: RootProvider<T, Zksync>,
+    l2_provider: RootProvider<Zksync>,
 }
 
-impl<T> L1TransactionReceipt<T>
-where
-    T: Transport + Clone,
-{
+impl L1TransactionReceipt {
     /// Creates a new `L1TransactionReceipt` object.
-    pub fn new(tx_receipt: TransactionReceipt, l2_provider: RootProvider<T, Zksync>) -> Self {
+    pub fn new(tx_receipt: TransactionReceipt, l2_provider: RootProvider<Zksync>) -> Self {
         Self {
             inner: tx_receipt,
             l2_provider,
@@ -37,7 +34,7 @@ where
     ///
     /// Will return an error if the transaction request used to create the object does not contain
     /// priority operation information (e.g. it doesn't correspond to an L1->L2 transaction).
-    pub fn get_l2_tx(&self) -> Result<PendingTransactionBuilder<T, Zksync>, L1CommunicationError> {
+    pub fn get_l2_tx(&self) -> Result<PendingTransactionBuilder<Zksync>, L1CommunicationError> {
         let l1_to_l2_tx_log = self
             .inner
             .inner

--- a/src/provider/layers/anvil_zksync.rs
+++ b/src/provider/layers/anvil_zksync.rs
@@ -60,6 +60,7 @@ where
 #[derive(Clone, Debug)]
 pub struct AnvilZKsyncProvider<P> {
     inner: P,
+    _anvil: Arc<AnvilZKsyncInstance>,
 }
 
 impl<P> AnvilZKsyncProvider<P>
@@ -69,7 +70,7 @@ where
     /// Creates a new `AnvilZKsyncProvider` with the given inner provider and anvil
     /// instance.
     pub fn new(inner: P, _anvil: Arc<AnvilZKsyncInstance>) -> Self {
-        Self { inner }
+        Self { inner, _anvil }
     }
 }
 

--- a/src/provider/layers/anvil_zksync.rs
+++ b/src/provider/layers/anvil_zksync.rs
@@ -2,7 +2,6 @@
 
 use alloy::{
     providers::{Provider, ProviderLayer, RootProvider},
-    transports::Transport,
 };
 use std::sync::{Arc, OnceLock};
 use url::Url;

--- a/src/provider/layers/anvil_zksync.rs
+++ b/src/provider/layers/anvil_zksync.rs
@@ -1,8 +1,6 @@
 //! Layer for `anvil-zksync` wrapper.
 
-use alloy::{
-    providers::{Provider, ProviderLayer, RootProvider},
-};
+use alloy::providers::{Provider, ProviderLayer, RootProvider};
 use std::sync::{Arc, OnceLock};
 use url::Url;
 

--- a/src/provider/layers/anvil_zksync.rs
+++ b/src/provider/layers/anvil_zksync.rs
@@ -4,10 +4,7 @@ use alloy::{
     providers::{Provider, ProviderLayer, RootProvider},
     transports::Transport,
 };
-use std::{
-    marker::PhantomData,
-    sync::{Arc, OnceLock},
-};
+use std::sync::{Arc, OnceLock};
 use url::Url;
 
 use crate::{
@@ -49,12 +46,11 @@ impl From<AnvilZKsync> for AnvilZKsyncLayer {
     }
 }
 
-impl<P, T> ProviderLayer<P, T, Zksync> for AnvilZKsyncLayer
+impl<P> ProviderLayer<P, Zksync> for AnvilZKsyncLayer
 where
-    P: Provider<T, Zksync>,
-    T: Transport + Clone,
+    P: Provider<Zksync>,
 {
-    type Provider = AnvilZKsyncProvider<P, T>;
+    type Provider = AnvilZKsyncProvider<P>;
 
     fn layer(&self, inner: P) -> Self::Provider {
         let anvil = self.instance();
@@ -65,35 +61,27 @@ where
 /// A provider that wraps an [`AnvilZKsyncInstance`], preventing the instance from
 /// being dropped while the provider is in use.
 #[derive(Clone, Debug)]
-pub struct AnvilZKsyncProvider<P, T> {
+pub struct AnvilZKsyncProvider<P> {
     inner: P,
-    _anvil: Arc<AnvilZKsyncInstance>,
-    _pd: PhantomData<fn() -> T>,
 }
 
-impl<P, T> AnvilZKsyncProvider<P, T>
+impl<P> AnvilZKsyncProvider<P>
 where
-    P: Provider<T, Zksync>,
-    T: Transport + Clone,
+    P: Provider<Zksync>,
 {
     /// Creates a new `AnvilZKsyncProvider` with the given inner provider and anvil
     /// instance.
     pub fn new(inner: P, _anvil: Arc<AnvilZKsyncInstance>) -> Self {
-        Self {
-            inner,
-            _anvil,
-            _pd: PhantomData,
-        }
+        Self { inner }
     }
 }
 
-impl<P, T> Provider<T, Zksync> for AnvilZKsyncProvider<P, T>
+impl<P> Provider<Zksync> for AnvilZKsyncProvider<P>
 where
-    P: Provider<T, Zksync>,
-    T: Transport + Clone,
+    P: Provider<Zksync>,
 {
     #[inline(always)]
-    fn root(&self) -> &RootProvider<T, Zksync> {
+    fn root(&self) -> &RootProvider<Zksync> {
         self.inner.root()
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -324,8 +324,6 @@ mod tests {
     use alloy::primitives::address;
     use alloy::primitives::{Address, Bytes, U256};
     use alloy::providers::{fillers::FillProvider, RootProvider};
-    use alloy::transports::http::Http;
-    use reqwest::Client;
     use std::net::SocketAddr;
 
     use crate::network::unsigned_tx::eip712::PaymasterParams;
@@ -342,8 +340,7 @@ mod tests {
     }
     type ZKsyncTestProvider = FillProvider<
         JoinFill<Identity, JoinFill<Eip712FeeFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-        RootProvider<Http<Client>, Zksync>,
-        Http<Client>,
+        RootProvider<Zksync>,
         Zksync,
     >;
     async fn run_server_and_test<Fut>(

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -42,29 +42,29 @@ type GetMsgProofRequest = (u64, Address, B256, Option<usize>);
 /// For convenience, you can use [`zksync_provider`] function instead.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait ZksyncProvider<T = BoxTransport>: Provider<T, Zksync>
+pub trait ZksyncProvider<T = BoxTransport>: Provider<Zksync>
 where
     T: Transport + Clone,
 {
     /// Gets the address of the main ZKsync contract on L1.
-    fn get_main_contract(&self) -> ProviderCall<T, NoParams, Address> {
+    fn get_main_contract(&self) -> ProviderCall<NoParams, Address> {
         self.client().request_noparams("zks_getMainContract").into()
     }
 
     /// Gets the address of the testnet paymaster ZKsync contract on L2, if it's present on the network.
-    fn get_testnet_paymaster(&self) -> ProviderCall<T, NoParams, Option<Address>> {
+    fn get_testnet_paymaster(&self) -> ProviderCall<NoParams, Option<Address>> {
         self.client()
             .request_noparams("zks_getTestnetPaymaster")
             .into()
     }
 
     /// Gets the L1 Chain ID.
-    fn get_l1_chain_id(&self) -> ProviderCall<T, NoParams, U64> {
+    fn get_l1_chain_id(&self) -> ProviderCall<NoParams, U64> {
         self.client().request_noparams("zks_L1ChainId").into()
     }
 
     /// Gets the latest L1 batch number.
-    fn get_l1_batch_number(&self) -> ProviderCall<T, NoParams, U64> {
+    fn get_l1_batch_number(&self) -> ProviderCall<NoParams, U64> {
         self.client().request_noparams("zks_L1BatchNumber").into()
     }
 
@@ -72,7 +72,7 @@ where
     fn estimate_fee(
         &self,
         tx: TransactionRequest,
-    ) -> ProviderCall<T, (TransactionRequest,), Eip712Fee> {
+    ) -> ProviderCall<(TransactionRequest,), Eip712Fee> {
         self.client().request("zks_estimateFee", (tx,)).into()
     }
 
@@ -80,26 +80,26 @@ where
     fn estimate_gas_l1_to_l2(
         &self,
         tx: TransactionRequest,
-    ) -> ProviderCall<T, (TransactionRequest,), U256> {
+    ) -> ProviderCall<(TransactionRequest,), U256> {
         self.client().request("zks_estimateGasL1ToL2", (tx,)).into()
     }
 
     /// Retrieves the bridge hub contract address.
-    fn get_bridgehub_contract(&self) -> ProviderCall<T, NoParams, Option<Address>> {
+    fn get_bridgehub_contract(&self) -> ProviderCall<NoParams, Option<Address>> {
         self.client()
             .request_noparams("zks_getBridgehubContract")
             .into()
     }
 
     /// Retrieves the addresses of canonical bridge contracts for ZKsync Era.
-    fn get_bridge_contracts(&self) -> ProviderCall<T, NoParams, BridgeAddresses> {
+    fn get_bridge_contracts(&self) -> ProviderCall<NoParams, BridgeAddresses> {
         self.client()
             .request_noparams("zks_getBridgeContracts")
             .into()
     }
 
     /// Retrieves the L1 base token address.
-    fn get_base_token_l1_address(&self) -> ProviderCall<T, NoParams, Address> {
+    fn get_base_token_l1_address(&self) -> ProviderCall<NoParams, Address> {
         self.client()
             .request_noparams("zks_getBaseTokenL1Address")
             .into()
@@ -118,7 +118,7 @@ where
     fn get_all_account_balances(
         &self,
         address: Address,
-    ) -> ProviderCall<T, (Address,), HashMap<Address, U256>> {
+    ) -> ProviderCall<(Address,), HashMap<Address, U256>> {
         self.client()
             .request("zks_getAllAccountBalances", (address,))
             .into()
@@ -139,7 +139,7 @@ where
         sender: Address,
         msg: B256,
         l2_log_position: Option<usize>,
-    ) -> ProviderCall<T, GetMsgProofRequest, Option<L2ToL1LogProof>> {
+    ) -> ProviderCall<GetMsgProofRequest, Option<L2ToL1LogProof>> {
         self.client()
             .request(
                 "zks_getL2ToL1MsgProof",
@@ -158,17 +158,14 @@ where
         &self,
         tx_hash: B256,
         l2_to_l1_log_index: Option<usize>,
-    ) -> ProviderCall<T, (B256, Option<usize>), Option<L2ToL1LogProof>> {
+    ) -> ProviderCall<(B256, Option<usize>), Option<L2ToL1LogProof>> {
         self.client()
             .request("zks_getL2ToL1LogProof", (tx_hash, l2_to_l1_log_index))
             .into()
     }
 
     /// Retrieves details for a given L2 block.
-    fn get_block_details(
-        &self,
-        block_number: u64,
-    ) -> ProviderCall<T, (u64,), Option<BlockDetails>> {
+    fn get_block_details(&self, block_number: u64) -> ProviderCall<(u64,), Option<BlockDetails>> {
         self.client()
             .request("zks_getBlockDetails", (block_number,))
             .into()
@@ -178,7 +175,7 @@ where
     fn get_transaction_details(
         &self,
         tx_hash: B256,
-    ) -> ProviderCall<T, (B256,), Option<TransactionDetails>> {
+    ) -> ProviderCall<(B256,), Option<TransactionDetails>> {
         self.client()
             .request("zks_getTransactionDetails", (tx_hash,))
             .into()
@@ -189,7 +186,7 @@ where
     fn get_raw_block_transactions(
         &self,
         block_number: u64,
-    ) -> ProviderCall<T, (u64,), Vec<Transaction>> {
+    ) -> ProviderCall<(u64,), Vec<Transaction>> {
         self.client()
             .request("zks_getRawBlockTransactions", (block_number,))
             .into()
@@ -199,14 +196,14 @@ where
     fn get_l1_batch_details(
         &self,
         l1_batch_number: u64,
-    ) -> ProviderCall<T, (u64,), Option<L1BatchDetails>> {
+    ) -> ProviderCall<(u64,), Option<L1BatchDetails>> {
         self.client()
             .request("zks_getL1BatchDetails", (l1_batch_number,))
             .into()
     }
 
     /// Retrieves the bytecode of a transaction by its hash.
-    fn get_bytecode_by_hash(&self, tx_hash: B256) -> ProviderCall<T, (B256,), Option<Bytes>> {
+    fn get_bytecode_by_hash(&self, tx_hash: B256) -> ProviderCall<(B256,), Option<Bytes>> {
         self.client()
             .request("zks_getBytecodeByHash", (tx_hash,))
             .into()
@@ -216,19 +213,19 @@ where
     fn get_l1_batch_block_range(
         &self,
         l1_batch_number: u64,
-    ) -> ProviderCall<T, (u64,), Option<(U64, U64)>> {
+    ) -> ProviderCall<(u64,), Option<(U64, U64)>> {
         self.client()
             .request("zks_getL1BatchBlockRange", (l1_batch_number,))
             .into()
     }
 
     /// Retrieves the current L1 gas price.
-    fn get_l1_gas_price(&self) -> ProviderCall<T, NoParams, U256> {
+    fn get_l1_gas_price(&self) -> ProviderCall<NoParams, U256> {
         self.client().request_noparams("zks_getL1GasPrice").into()
     }
 
     /// Retrieves the current fee parameters.
-    fn get_fee_params(&self) -> ProviderCall<T, NoParams, FeeParams> {
+    fn get_fee_params(&self) -> ProviderCall<NoParams, FeeParams> {
         self.client().request_noparams("zks_getFeeParams").into()
     }
 
@@ -236,7 +233,7 @@ where
     fn get_protocol_version(
         &self,
         version_id: Option<u16>,
-    ) -> ProviderCall<T, (Option<u16>,), Option<ProtocolVersion>> {
+    ) -> ProviderCall<(Option<u16>,), Option<ProtocolVersion>> {
         self.client()
             .request("zks_getProtocolVersion", (version_id,))
             .into()
@@ -259,7 +256,7 @@ where
         address: Address,
         keys: Vec<B256>,
         l1_batch_number: u64,
-    ) -> ProviderCall<T, (Address, Vec<B256>, u64), Option<Proof>> {
+    ) -> ProviderCall<(Address, Vec<B256>, u64), Option<Proof>> {
         self.client()
             .request("zks_getProof", (address, keys, l1_batch_number))
             .into()
@@ -271,9 +268,7 @@ where
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait ZksyncProviderWithWallet<T = BoxTransport>:
-    ZksyncProvider<T> + WalletProvider<Zksync>
-where
-    T: Transport + Clone,
+    ZksyncProvider + WalletProvider<Zksync>
 {
     /// Deposits specified L1 token to the L2 address.
     ///
@@ -291,28 +286,18 @@ where
         &self,
         deposit_request: &DepositRequest,
         l1_provider: &P,
-    ) -> Result<L1TransactionReceipt<T>, L1CommunicationError>
+    ) -> Result<L1TransactionReceipt, L1CommunicationError>
     where
-        P: alloy::providers::Provider<T, Ethereum>,
+        P: alloy::providers::Provider<Ethereum>,
     {
         let deposit_executor = DepositExecutor::new(l1_provider, self, deposit_request);
         deposit_executor.execute().await
     }
 }
 
-impl<P, T> ZksyncProviderWithWallet<T> for P
-where
-    T: Transport + Clone,
-    P: WalletProvider<Zksync> + Provider<T, Zksync>,
-{
-}
+impl<P> ZksyncProviderWithWallet for P where P: WalletProvider<Zksync> + Provider<Zksync> {}
 
-impl<P, T> ZksyncProvider<T> for P
-where
-    T: Transport + Clone,
-    P: Provider<T, Zksync>,
-{
-}
+impl<P> ZksyncProvider for P where P: Provider<Zksync> {}
 
 impl RecommendedFillers for Zksync {
     type RecommendedFillers = JoinFill<Eip712FeeFiller, JoinFill<NonceFiller, ChainIdFiller>>;

--- a/src/provider/provider_builder_ext.rs
+++ b/src/provider/provider_builder_ext.rs
@@ -15,17 +15,12 @@ use crate::{
 
 type AnvilZKsyncProviderResult<T> = Result<T, AnvilZKsyncError>;
 type JoinedZksyncWalletFiller<F> = JoinFill<F, WalletFiller<ZksyncWallet>>;
-type ZksyncHttpTransport = alloy::transports::http::Http<reqwest::Client>;
 
 /// ZKsync-specific extensions for the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html).
 pub trait ProviderBuilderExt<L, F>: Sized
 where
-    F: TxFiller<Zksync> + ProviderLayer<L::Provider, ZksyncHttpTransport, Zksync>,
-    L: ProviderLayer<
-        AnvilZKsyncProvider<RootProvider<ZksyncHttpTransport, Zksync>, ZksyncHttpTransport>,
-        ZksyncHttpTransport,
-        Zksync,
-    >,
+    F: TxFiller<Zksync> + ProviderLayer<L::Provider, Zksync>,
+    L: ProviderLayer<AnvilZKsyncProvider<RootProvider<Zksync>>, Zksync>,
 {
     /// Build a provider that would spawn `anvil-zksync` instance in background and will use it.
     fn on_anvil_zksync(self) -> F::Provider;
@@ -33,11 +28,7 @@ where
     /// Same as [`on_anvil_zksync`](Self::on_anvil_zksync), but also configures a wallet backed by anvil-zksync keys.
     fn on_anvil_zksync_with_wallet(
         self,
-    ) -> <JoinedZksyncWalletFiller<F> as ProviderLayer<
-        L::Provider,
-        ZksyncHttpTransport,
-        Zksync,
-    >>::Provider;
+    ) -> <JoinedZksyncWalletFiller<F> as ProviderLayer<L::Provider, Zksync>>::Provider;
 
     /// Same as [`on_anvil_zksync`](Self::on_anvil_zksync), allows to configure `anvil-zksync`.
     fn on_anvil_zksync_with_config(self, f: impl FnOnce(AnvilZKsync) -> AnvilZKsync)
@@ -47,33 +38,21 @@ where
     fn on_anvil_zksync_with_wallet_and_config(
         self,
         f: impl FnOnce(AnvilZKsync) -> AnvilZKsync,
-    ) -> <JoinedZksyncWalletFiller<F> as ProviderLayer<
-        L::Provider,
-        ZksyncHttpTransport,
-        Zksync,
-    >>::Provider;
+    ) -> <JoinedZksyncWalletFiller<F> as ProviderLayer<L::Provider, Zksync>>::Provider;
 
     /// Fallible version of [`on_anvil_zksync_with_wallet_and_config`](Self::on_anvil_zksync_with_wallet_and_config).
     fn try_on_anvil_zksync_with_wallet_and_config(
         self,
         f: impl FnOnce(AnvilZKsync) -> AnvilZKsync,
     ) -> AnvilZKsyncProviderResult<
-        <JoinedZksyncWalletFiller<F> as ProviderLayer<
-            L::Provider,
-            ZksyncHttpTransport,
-            Zksync,
-        >>::Provider,
+        <JoinedZksyncWalletFiller<F> as ProviderLayer<L::Provider, Zksync>>::Provider,
     >;
 }
 
 impl<L, F> ProviderBuilderExt<L, F> for ProviderBuilder<L, F, Zksync>
 where
-    F: TxFiller<Zksync> + ProviderLayer<L::Provider, ZksyncHttpTransport, Zksync>,
-    L: ProviderLayer<
-        AnvilZKsyncProvider<RootProvider<ZksyncHttpTransport, Zksync>, ZksyncHttpTransport>,
-        ZksyncHttpTransport,
-        Zksync,
-    >,
+    F: TxFiller<Zksync> + ProviderLayer<L::Provider, Zksync>,
+    L: ProviderLayer<AnvilZKsyncProvider<RootProvider<Zksync>>, Zksync>,
 {
     fn on_anvil_zksync(self) -> F::Provider {
         self.on_anvil_zksync_with_config(std::convert::identity)
@@ -81,11 +60,7 @@ where
 
     fn on_anvil_zksync_with_wallet(
         self,
-    ) -> <JoinedZksyncWalletFiller<F> as ProviderLayer<
-        L::Provider,
-        ZksyncHttpTransport,
-        Zksync,
-    >>::Provider{
+    ) -> <JoinedZksyncWalletFiller<F> as ProviderLayer<L::Provider, Zksync>>::Provider {
         self.on_anvil_zksync_with_wallet_and_config(std::convert::identity)
     }
 
@@ -102,11 +77,7 @@ where
     fn on_anvil_zksync_with_wallet_and_config(
         self,
         f: impl FnOnce(AnvilZKsync) -> AnvilZKsync,
-    ) -> <JoinedZksyncWalletFiller<F> as ProviderLayer<
-        L::Provider,
-        ZksyncHttpTransport,
-        Zksync,
-    >>::Provider{
+    ) -> <JoinedZksyncWalletFiller<F> as ProviderLayer<L::Provider, Zksync>>::Provider {
         self.try_on_anvil_zksync_with_wallet_and_config(f).unwrap()
     }
 
@@ -118,12 +89,8 @@ where
         self,
         f: impl FnOnce(AnvilZKsync) -> AnvilZKsync,
     ) -> AnvilZKsyncProviderResult<
-        <JoinedZksyncWalletFiller<F> as ProviderLayer<
-            L::Provider,
-            ZksyncHttpTransport,
-            Zksync,
-        >>::Provider,
-    >{
+        <JoinedZksyncWalletFiller<F> as ProviderLayer<L::Provider, Zksync>>::Provider,
+    > {
         use alloy::signers::Signer;
 
         let anvil_zksync_layer = AnvilZKsyncLayer::from(f(Default::default()));


### PR DESCRIPTION
With the new version of alloy 0.11.0, many breaking changes were introduced that required some deep investigation of the code, mainly in places I haven't modified before.

The changes introduced in alloy mainly were these two:
 - Removing T (for Transport) from the codebase generated a cascade effect affecting multiple files
 - Implementing Typed2718
 
Also, I took the opportunity to update many other old dependencies.