### PR TITLE
chore: make encode_with_signature public

### DIFF
--- a/src/network/unsigned_tx/eip712/mod.rs
+++ b/src/network/unsigned_tx/eip712/mod.rs
@@ -13,7 +13,7 @@ pub use self::meta::{Eip712Meta, PaymasterParams};
 pub use self::utils::{hash_bytecode, BytecodeHashError};
 
 mod meta;
-mod signing;
+pub mod signing;
 mod utils;
 
 /// A ZKsync-native transaction type with additional fields.
@@ -107,7 +107,7 @@ impl TxEip712 {
 
     /// Inner encoding function that is used for both rlp [`Encodable`] trait and for calculating
     /// hash that for eip2718 does not require a rlp header.
-    pub(crate) fn encode_with_signature(
+    pub fn encode_with_signature(
         &self,
         signature: &Signature,
         out: &mut dyn BufMut,


### PR DESCRIPTION
The ZKsync SSO SDK [depends on this method](https://github.com/matter-labs/zksync-sso/blob/0ce81b335e023cf53174851150dd74e980f6d5b7/packages/sdk-platforms/rust/zksync-sso/crates/sdk/src/utils/manual_build_transaction/transaction_builder.rs#L141) to encode transactions with custom signatures. This PR makes the `encode_with_signature` function public.